### PR TITLE
404 http code instead of 500

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Jenkins shared library for integrating Keptn Use Cases with your Jenkins Pipelin
 | [@grabnerandi](https://github.com/grabnerandi), [@kristofre](https://github.com/kristofre) | 3.0 | 0.7.x | Supporting 0.7.0 API Endpoints |
 | [@grabnerandi](https://github.com/grabnerandi), [@kristofre](https://github.com/kristofre) | 3.1 | 0.7.x | Sending *buildId* label to Keptn |
 | [@grabnerandi](https://github.com/grabnerandi), [@kristofre](https://github.com/kristofre) | 3.2 | 0.7.x | Adding custom label support for Keptn 0.7.x |
+| [@grabnerandi](https://github.com/grabnerandi), [@kristofre](https://github.com/kristofre) | 3.3 | 0.7.1 | Improved Evaluation done event handling in Keptn |
 
 ## Watch the tutorial webinar on YouTube
 

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -619,11 +619,11 @@ def waitForEvaluationDoneEvent(Map args) {
                     httpMode: 'GET', 
                     responseHandle: 'STRING', 
                     url: "${keptn_endpoint}/v1/event?keptnContext=${keptn_context}&type=sh.keptn.events.evaluation-done", 
-                    validResponseCodes: "100:500", 
+                    validResponseCodes: "100:404", 
                     ignoreSslErrors: true
 
-                //The API returns a response code 500 error if the evalution done event does not exisit
-                if (response.status == 500 || response.content.contains("No Keptn sh.keptn.events.evaluation-done event found for context") ) {
+                //The API returns a response code 404 error if the evalution done event does not exist
+                if (response.status == 404 || response.content.contains("No Keptn sh.keptn.events.evaluation-done event found for context") ) {
                     sleep 10
                     return false
                 } else {


### PR DESCRIPTION
Improved validation for waiting of the evaluation results in Keptn (it was improved in 7.1 to 404 instead of 500). Otherwise the Jenkins pipelines will break after upgrade to Keptn 7.1 using this plugin.