### PR TITLE
Added additional error trap,

### DIFF
--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -677,7 +677,7 @@ def waitForEvaluationDoneEvent(Map args) {
                     ignoreSslErrors: true
 
                 //The API returns a response code 404 error if the evalution done event does not exist
-                if (response.status == 404 || response.content.contains("No Keptn sh.keptn.event.evaluation.finished event found for context") || response.contentEquals("[]")  ) {
+                if (response.status == 404 || response.content.contains("No Keptn sh.keptn.event.evaluation.finished event found for context") || response.content.matches("[]")  ) {
                     if (response.content.contains("troubleshooting") ) {
                         evalResponse = response.content
                         return true

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -693,17 +693,17 @@ def waitForEvaluationDoneEvent(Map args) {
         }
     }
     
-    //if (evalResponse.content.contains("troubleshooting") ) {
-    //    echo "Received invalid keptn evaluation results"
-    //    if (setBuildResult) {
+    if (response.content.contains("troubleshooting") ) {
+        echo "Received invalid keptn evaluation results"
+        if (setBuildResult) {
             // currentBuild.result = 'FAILURE'
-    //        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-    //            error("Didnt receive a proper keptn evaluation result")
-    //            // sh "exit 1"
-    //        }
-    //    }
-    //    return false;
-    //} 
+            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                error("Didnt receive a proper keptn evaluation result")
+                // sh "exit 1"
+            }
+        }
+        return false;
+    } 
     
     if (evalResponse == "") {
         echo "Didnt receive any successful keptn evaluation results"

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -688,7 +688,7 @@ def waitForEvaluationDoneEvent(Map args) {
         }
     }
       
-    if (evalResponse == "" || evalResponse.contains("troubleshooting") || evalResponse.equalsIgnoreCase("[]") {
+    if (evalResponse == "" || evalResponse.contains("troubleshooting") || evalResponse.equalsIgnoreCase("[]") ) {
         echo "Didnt receive any successful keptn evaluation results"
         if (setBuildResult) {
             // currentBuild.result = 'FAILURE'

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -677,8 +677,8 @@ def waitForEvaluationDoneEvent(Map args) {
                     ignoreSslErrors: true
 
                 //The API returns a response code 404 error if the evalution done event does not exist
-                if (response.status == 404 || response.content.contains("No Keptn sh.keptn.event.evaluation.finished event found for context") || response.content.matches("[]")  ) {
-                    if (response.content.contains("troubleshooting") ) {
+                if (response.status == 404 || response.content.contains("No Keptn sh.keptn.event.evaluation.finished event found for context") ) {
+                    if (response.content.contains("troubleshooting") || response.content.equalsIgnoreCase("[]") ) {
                         evalResponse = response.content
                         return true
                     } else {   
@@ -693,7 +693,7 @@ def waitForEvaluationDoneEvent(Map args) {
         }
     }
     
-    if (evalResponse.contains("troubleshooting") ) {
+    if (evalResponse.contains("troubleshooting") || response.content.equalsIgnoreCase("[]") ) {
         echo "Received invalid keptn evaluation results"
         if (setBuildResult) {
             // currentBuild.result = 'FAILURE'

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -678,8 +678,13 @@ def waitForEvaluationDoneEvent(Map args) {
 
                 //The API returns a response code 404 error if the evalution done event does not exist
                 if (response.status == 404 || response.content.contains("No Keptn sh.keptn.event.evaluation.finished event found for context") || response.content.contains("[]")  ) {
+                    if (response.content.contains("troubleshooting") ) {
+                        evalResponse = response.content
+                        return true
+                    } else {   
                     sleep 10
                     return false
+                    }    
                 } else {
                     evalResponse = response.content
                     return true
@@ -687,6 +692,18 @@ def waitForEvaluationDoneEvent(Map args) {
             }
         }
     }
+    
+    if (evalResponse.content.contains("troubleshooting") ) {
+        echo "Received invalid keptn evaluation results"
+        if (setBuildResult) {
+            // currentBuild.result = 'FAILURE'
+            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                error("Didnt receive a proper keptn evaluation result")
+                // sh "exit 1"
+            }
+        }
+        return false;
+    } 
     
     if (evalResponse == "") {
         echo "Didnt receive any successful keptn evaluation results"

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -677,7 +677,7 @@ def waitForEvaluationDoneEvent(Map args) {
                     ignoreSslErrors: true
 
                 //The API returns a response code 404 error if the evalution done event does not exist
-                if (response.status == 404 || response.content.contains("No Keptn sh.keptn.event.evaluation.finished event found for context") || response.content.contains("[]")  ) {
+                if (response.status == 404 || response.content.contains("No Keptn sh.keptn.event.evaluation.finished event found for context") || response.contentEquals("[]")  ) {
                     if (response.content.contains("troubleshooting") ) {
                         evalResponse = response.content
                         return true

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -693,7 +693,7 @@ def waitForEvaluationDoneEvent(Map args) {
         }
     }
     
-    if (response.content.contains("troubleshooting") ) {
+    if (evalResponse.contains("troubleshooting") ) {
         echo "Received invalid keptn evaluation results"
         if (setBuildResult) {
             // currentBuild.result = 'FAILURE'

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -693,17 +693,17 @@ def waitForEvaluationDoneEvent(Map args) {
         }
     }
     
-    if (evalResponse.content.contains("troubleshooting") ) {
-        echo "Received invalid keptn evaluation results"
-        if (setBuildResult) {
+    //if (evalResponse.content.contains("troubleshooting") ) {
+    //    echo "Received invalid keptn evaluation results"
+    //    if (setBuildResult) {
             // currentBuild.result = 'FAILURE'
-            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                error("Didnt receive a proper keptn evaluation result")
-                // sh "exit 1"
-            }
-        }
-        return false;
-    } 
+    //        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+    //            error("Didnt receive a proper keptn evaluation result")
+    //            // sh "exit 1"
+    //        }
+    //    }
+    //    return false;
+    //} 
     
     if (evalResponse == "") {
         echo "Didnt receive any successful keptn evaluation results"

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -693,7 +693,7 @@ def waitForEvaluationDoneEvent(Map args) {
         }
     }
     
-    if (evalResponse.contains("troubleshooting") || response.content.equalsIgnoreCase("[]") ) {
+    if (evalResponse.contains("troubleshooting") || evalResponse.equalsIgnoreCase("[]") ) {
         echo "Received invalid keptn evaluation results"
         if (setBuildResult) {
             // currentBuild.result = 'FAILURE'

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -677,14 +677,9 @@ def waitForEvaluationDoneEvent(Map args) {
                     ignoreSslErrors: true
 
                 //The API returns a response code 404 error if the evalution done event does not exist
-                if (response.status == 404 || response.content.contains("No Keptn sh.keptn.event.evaluation.finished event found for context") ) {
-                    if (response.content.contains("troubleshooting") || response.content.equalsIgnoreCase("[]") ) {
-                        evalResponse = response.content
-                        return true
-                    } else {   
+                if (response.status == 404 || response.content.contains("No Keptn sh.keptn.event.evaluation.finished event found for context") ) { 
                     sleep 10
-                    return false
-                    }    
+                    return false  
                 } else {
                     evalResponse = response.content
                     return true
@@ -692,20 +687,8 @@ def waitForEvaluationDoneEvent(Map args) {
             }
         }
     }
-    
-    if (evalResponse.contains("troubleshooting") || evalResponse.equalsIgnoreCase("[]") ) {
-        echo "Received invalid keptn evaluation results"
-        if (setBuildResult) {
-            // currentBuild.result = 'FAILURE'
-            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                error("Didnt receive a proper keptn evaluation result")
-                // sh "exit 1"
-            }
-        }
-        return false;
-    } 
-    
-    if (evalResponse == "") {
+      
+    if (evalResponse == "" || evalResponse.contains("troubleshooting") || evalResponse.equalsIgnoreCase("[]") {
         echo "Didnt receive any successful keptn evaluation results"
         if (setBuildResult) {
             // currentBuild.result = 'FAILURE'


### PR DESCRIPTION
If the result from Keptn does not return a proper result from the API. 
It will contain "[]" which can also be the case when waiting for a result.
Added additional trap if the keptn result returns a bad result from the API. 
The returned result will contain "troubleshooting". This is then used to kick out of the waiting for result function.
Then set a message that the result was improper and set result to failure.

This is in reference to issue https://github.com/keptn-sandbox/keptn-jenkins-library/issues/26

This fix should work with keptn 0.8.x