### PR TITLE
PR to address date formatting for starttime and endtime. 

### DIFF
--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -551,8 +551,8 @@ def sendStartEvaluationEvent(Map args) {
         if (seconds > 0) {
             starttime = getNow().minusSeconds((int)starttime.toInteger()).toString()
            
-            LocalDateTime a = LocalDateTime.now()
-            LocalDateTime t = a.plusSeconds(seconds);
+            def LocalDateTime a = LocalDateTime.now()
+            def LocalDateTime t = a.plusSeconds(seconds);
             echo "Setting localtime to ${t}"
             
             def format = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -1,6 +1,7 @@
 package sh.keptn
 
-import java.text.SimpleDateFormat
+import java.time.LocalDateTime; // Import the LocalDateTime class
+import java.time.format.DateTimeFormatter; // Import the DateTimeFormatter class
 import org.jenkinsci.plugins.plaincredentials.StringCredentials
 import com.cloudbees.plugins.credentials.CredentialsProvider
 import com.cloudbees.plugins.credentials.domains.DomainRequirement
@@ -547,11 +548,9 @@ def sendStartEvaluationEvent(Map args) {
         if (seconds > 0) {
             starttime = getNow().minusSeconds((int)starttime.toInteger()).toString()
             
-            DateTimeZone timeZone = DateTimeZone.forID( "Europe/Amsterdam" );
-            DateTime dateTime = formatter.withZone( timeZone ).parseDateTime( starttime );
-            DateTimeFormatter formatter = DateTimeFormat.forPattern( "dd/MM/yyyy" );
-            DateTime dateTimeUtcGmt = dateTime.withZone( DateTimeZone.UTC );
-            echo "Setting dateTimeUtcGmt to ${dateTimeUtcGmt}"
+            DateTimeFormatter myFormatObj = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+            String formattedDate = starttime.format(myFormatObj);
+             echo "Setting formatted date to ${formattedDate}"
             
             def format = "yyyy-MM-dd'T'HH:mm:ss.SSS"
             def parsedtime = new SimpleDateFormat(format).parse(starttime)

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -546,8 +546,11 @@ def sendStartEvaluationEvent(Map args) {
         seconds = starttime.toInteger()
         if (seconds > 0) {
             starttime = getNow().minusSeconds((int)starttime.toInteger()).toString()
-            
            
+            LocalDateTime a = LocalDateTime.now()
+            LocalDateTime t = a.plusSeconds(seconds);
+            echo "Setting localtime to ${t}"
+            
             def format = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
             def parsedtime = new SimpleDateFormat(format).parse(starttime)
             echo "Setting parsedtime to ${parsedtime}"

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -550,7 +550,6 @@ def sendStartEvaluationEvent(Map args) {
            
             def LocalDateTime a = LocalDateTime.now()
             def LocalDateTime t = a.plusSeconds(seconds)
-            def format = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
             def newtime = t.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ"))
             
             echo "Setting localtime to ${t}"

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -1,5 +1,6 @@
 package sh.keptn
 
+import java.time
 import java.text.SimpleDateFormat 
 import org.jenkinsci.plugins.plaincredentials.StringCredentials
 import com.cloudbees.plugins.credentials.CredentialsProvider

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -1,6 +1,9 @@
 package sh.keptn
 
-import java.time
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 import java.text.SimpleDateFormat 
 import org.jenkinsci.plugins.plaincredentials.StringCredentials
 import com.cloudbees.plugins.credentials.CredentialsProvider

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -568,6 +568,9 @@ def sendStartEvaluationEvent(Map args) {
             
             def starttimeformatted = starttimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
             
+            timestampformatted = timestampFormatter[starttimelocal]
+            echo "new timestamp formatted: ${timestampformatted}"
+            
             starttime = starttimeformatted
          
             echo "Setting starttime to ${starttime}"

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -546,8 +546,8 @@ def sendStartEvaluationEvent(Map args) {
         seconds = starttime.toInteger()
         if (seconds > 0) {
             starttime = getNow().minusSeconds((int)starttime.toInteger()).toString()
-            SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-            starttime = format.parse(starttime)
+            SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+            Date starttime = format.parse(starttime)
             echo "Setting starttime to ${starttime}"
         } else {
             echo "No negative numbers allowed for starttime!"

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -422,7 +422,7 @@ def markEvaluationStartTime() {
     def LocalDateTime starttimelocal = LocalDateTime.now()       
     def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));    
     
-    starttime = starttimeformatted
+    startTime = starttimeformatted
 
     def keptnContextFileJson
     if (fileExists(file: getKeptnInitJsonFilename())) {

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -1,6 +1,6 @@
 package sh.keptn
 
-import java.text.*
+import java.text.SimpleDateFormat
 import org.jenkinsci.plugins.plaincredentials.StringCredentials
 import com.cloudbees.plugins.credentials.CredentialsProvider
 import com.cloudbees.plugins.credentials.domains.DomainRequirement
@@ -546,8 +546,9 @@ def sendStartEvaluationEvent(Map args) {
         seconds = starttime.toInteger()
         if (seconds > 0) {
             starttime = getNow().minusSeconds((int)starttime.toInteger()).toString()
-            SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-            Date starttime = format.parse(starttime)
+            def format = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+            def parsedtime = new SimpleDateFormat(format).parse(starttime)
+            echo "Setting parsedtime to ${parsedtime}"
             echo "Setting starttime to ${starttime}"
         } else {
             echo "No negative numbers allowed for starttime!"

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -33,6 +33,11 @@ def getNow() {
     return java.time.Instant.now()
 }
 
+def dateFormatter(timestamp) {
+    def timeformatted = timestamp.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
+    return timeformatted
+}    
+
 String getKeptnApiToken() {
     String keptn_api_token = env.KEPTN_API_TOKEN
     if (keptn_api_token == null) {
@@ -419,7 +424,10 @@ def markEvaluationStartTime() {
     //def startTime = getNow().toString()
     
     def LocalDateTime starttimelocal = LocalDateTime.now()       
-    def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))    
+    def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
+    
+    def timestampformatted = dateFormatter(starttimelocal)
+    echo "new timestamp formatted: ${timestampformatted}"
     
     startTime = starttimeformatted
     echo "write starttime to file - ${startTime}"
@@ -557,14 +565,11 @@ def sendStartEvaluationEvent(Map args) {
            
             def LocalDateTime starttimelocal = LocalDateTime.now()
             def LocalDateTime starttimeminus = starttimelocal.minusSeconds(seconds)            
-            //echo "Setting starttime minus seconds to ${t}"
             
             def starttimeformatted = starttimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
-            //echo "Setting localtime to ${t2}"
             
             starttime = starttimeformatted
-            //def parsedtime = new SimpleDateFormat(format).parse(t)
-            //echo "Setting parsedtime to ${parsedtime}"          
+         
             echo "Setting starttime to ${starttime}"
         } else {
             echo "No negative numbers allowed for starttime!"
@@ -579,10 +584,8 @@ def sendStartEvaluationEvent(Map args) {
             
             def LocalDateTime endtimelocal = LocalDateTime.now()
             def LocalDateTime endtimeminus = endtimelocal.minusSeconds(seconds)            
-            //echo "Setting endtime to ${et}"
                      
             def endtimeformatted = endtimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
-            //echo "Setting localtime to ${et2}"
             
             endtime = endtimeformatted            
             echo "Setting endtime to ${endtime}"         
@@ -596,7 +599,6 @@ def sendStartEvaluationEvent(Map args) {
         
         def LocalDateTime endtimelocal = LocalDateTime.now()                        
         def endtimeformatted = endtimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
-        //echo "Setting localtime to ${et2}"
             
         endtime = endtimeformatted    
         echo "Endttime empty. Setting endtime to Now: ${endtime}"

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -546,9 +546,17 @@ def sendStartEvaluationEvent(Map args) {
         seconds = starttime.toInteger()
         if (seconds > 0) {
             starttime = getNow().minusSeconds((int)starttime.toInteger()).toString()
+            
+            DateTimeZone timeZone = DateTimeZone.forID( "Europe/Amsterdam" );
+            DateTime dateTime = formatter.withZone( timeZone ).parseDateTime( starttime );
+            DateTimeFormatter formatter = DateTimeFormat.forPattern( "dd/MM/yyyy" );
+            DateTime dateTimeUtcGmt = dateTime.withZone( DateTimeZone.UTC );
+            echo "Setting dateTimeUtcGmt to ${dateTimeUtcGmt}"
+            
             def format = "yyyy-MM-dd'T'HH:mm:ss.SSS"
             def parsedtime = new SimpleDateFormat(format).parse(starttime)
             echo "Setting parsedtime to ${parsedtime}"
+            
             echo "Setting starttime to ${starttime}"
         } else {
             echo "No negative numbers allowed for starttime!"

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -545,6 +545,8 @@ def sendStartEvaluationEvent(Map args) {
         seconds = starttime.toInteger()
         if (seconds > 0) {
             starttime = getNow().minusSeconds((int)starttime.toInteger()).toString()
+            SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+            starttime = format.parse(starttime)
             echo "Setting starttime to ${starttime}"
         } else {
             echo "No negative numbers allowed for starttime!"

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -1,9 +1,6 @@
 package sh.keptn
 
-import java.time.LocalDateTime
-import java.time.OffsetDateTime
-import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
+import java.time.*
 import java.text.SimpleDateFormat 
 import org.jenkinsci.plugins.plaincredentials.StringCredentials
 import com.cloudbees.plugins.credentials.CredentialsProvider

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -708,7 +708,7 @@ def waitForEvaluationDoneEvent(Map args) {
                     customHeaders: [[maskValue: true, name: 'x-token', value: "${keptn_api_token}"]], 
                     httpMode: 'GET', 
                     responseHandle: 'STRING', 
-                    url: "${keptn_endpoint}/mongodb-datastore/event?keptnContext=${keptn_context}&type=sh.keptn.event.evaluation.finished", 
+                    url: "${keptn_endpoint}/mongodb-datastore/event?keptnContext=${keptn_context}&type=sh.keptn.event.evaluation.finished&pageSize=20", 
                     validResponseCodes: "100:404", 
                     ignoreSslErrors: true
 

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -418,6 +418,14 @@ def keptnAddStageResources(file, remoteUri) {
  */
 def markEvaluationStartTime() {
     def startTime = getNow().toString()
+    
+    def LocalDateTime starttimelocal = LocalDateTime.now()
+    def LocalDateTime starttimeminus = starttimelocal.minusSeconds(seconds)            
+    //echo "Setting starttime minus seconds to ${t}"
+            
+    def starttimeformatted = starttimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));    
+    
+    starttime = starttimeformatted
 
     def keptnContextFileJson
     if (fileExists(file: getKeptnInitJsonFilename())) {

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -549,11 +549,8 @@ def sendStartEvaluationEvent(Map args) {
         if (seconds > 0) {
             starttime = getNow().minusSeconds((int)starttime.toInteger()).toString()
             
-            DateTimeFormatter myFormatObj = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS")
-            String formattedDate = starttime.format(myFormatObj);
-             echo "Setting formatted date to ${formattedDate}"
-            
-            def format = "yyyy-MM-dd'T'HH:mm:ss.SSS"
+           
+            def format = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
             def parsedtime = new SimpleDateFormat(format).parse(starttime)
             echo "Setting parsedtime to ${parsedtime}"
             

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -1,6 +1,6 @@
 package sh.keptn
 
-import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -590,7 +590,7 @@ def sendStartEvaluationEvent(Map args) {
         endtime = getNow().toString()
         
         def LocalDateTime ea = LocalDateTime.now()                        
-        def et2 = et.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
+        def et2 = ea.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
         //echo "Setting localtime to ${et2}"
             
         endtime = et2    

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -688,7 +688,7 @@ def waitForEvaluationDoneEvent(Map args) {
         }
     }
       
-    if (evalResponse == "" || evalResponse.contains("troubleshooting") || evalResponse.equalsIgnoreCase("[]") {
+    if (evalResponse == "" || evalResponse.contains("troubleshooting") || evalResponse.equalsIgnoreCase("[]") ) {
         echo "Didnt receive any successful keptn evaluation results"
         if (setBuildResult) {
             // currentBuild.result = 'FAILURE'

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -550,17 +550,18 @@ def sendStartEvaluationEvent(Map args) {
             starttime = getNow().minusSeconds((int)starttime.toInteger()).toString()
            
             def LocalDateTime a = LocalDateTime.now()
-            def LocalDateTime t = a.plusSeconds(seconds)
+            echo "Setting localtime to ${a}"
             
+            def LocalDateTime t = a.plusSeconds(seconds)            
             echo "Setting localtime to ${t}"
             
             def format = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
             
-            def t2 = t.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ"));
+            def t2 = t.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS"));
+            echo "Setting localtime to ${t2}"
             
-            echo "Setting localtime to ${t}"
             //def parsedtime = new SimpleDateFormat(format).parse(t)
-            echo "Setting parsedtime to ${parsedtime}"
+            //echo "Setting parsedtime to ${parsedtime}"
             
             echo "Setting starttime to ${starttime}"
         } else {

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -677,8 +677,8 @@ def waitForEvaluationDoneEvent(Map args) {
                     ignoreSslErrors: true
 
                 //The API returns a response code 404 error if the evalution done event does not exist
-                if (response.status == 404 || response.content.contains("No Keptn sh.keptn.event.evaluation.finished event found for context") || response.content.matches("[]")  ) {
-                    if (response.content.contains("troubleshooting") ) {
+                if (response.status == 404 || response.content.contains("No Keptn sh.keptn.event.evaluation.finished event found for context") ) {
+                    if (response.content.contains("troubleshooting") || response.content.equalsIgnoreCase("[]") ) {
                         evalResponse = response.content
                         return true
                     } else {   
@@ -693,7 +693,7 @@ def waitForEvaluationDoneEvent(Map args) {
         }
     }
     
-    if (evalResponse.contains("troubleshooting") ) {
+    if (evalResponse.contains("troubleshooting") || response.content.equalsIgnoreCase("[]") ) {
         echo "Received invalid keptn evaluation results"
         if (setBuildResult) {
             // currentBuild.result = 'FAILURE'

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -1,7 +1,5 @@
 package sh.keptn
 
-import java.time.LocalDateTime; // Import the LocalDateTime class
-import java.time.format.DateTimeFormatter; // Import the DateTimeFormatter class
 import java.text.SimpleDateFormat 
 import org.jenkinsci.plugins.plaincredentials.StringCredentials
 import com.cloudbees.plugins.credentials.CredentialsProvider

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -548,6 +548,7 @@ def sendStartEvaluationEvent(Map args) {
         seconds = starttime.toInteger()
         if (seconds > 0) {
             starttime = getNow().minusSeconds((int)starttime.toInteger()).toString()
+            echo "Setting starttime to ${starttime}"
            
             def LocalDateTime a = LocalDateTime.now()
             echo "Setting localtime to ${a}"
@@ -560,6 +561,7 @@ def sendStartEvaluationEvent(Map args) {
             def t2 = t.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
             echo "Setting localtime to ${t2}"
             
+            starttime = t2
             //def parsedtime = new SimpleDateFormat(format).parse(t)
             //echo "Setting parsedtime to ${parsedtime}"
             
@@ -574,6 +576,21 @@ def sendStartEvaluationEvent(Map args) {
         if (seconds > 0) {
             endtime = getNow().minusSeconds((int)endtime.toInteger()).toString()
             echo "Setting endtime to ${endtime}"
+            
+            def LocalDateTime ea = LocalDateTime.now()
+            echo "Setting localtime to ${ea}"
+            
+            def LocalDateTime et = ea.plusSeconds(seconds)            
+            echo "Setting localtime to ${et}"
+            
+            def format = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+            
+            def et2 = et.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
+            echo "Setting localtime to ${et2}"
+            
+            endtime = et2            
+            
+            
         } else {
             echo "No negative numbers allowed for endtime!"
             return false;

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -555,7 +555,11 @@ def sendStartEvaluationEvent(Map args) {
             echo "Setting localtime to ${t}"
             
             def format = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
-            def parsedtime = new SimpleDateFormat(format).parse(t)
+            
+            def t2 = localDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ"));
+            
+            echo "Setting localtime to ${t}"
+            //def parsedtime = new SimpleDateFormat(format).parse(t)
             echo "Setting parsedtime to ${parsedtime}"
             
             echo "Setting starttime to ${starttime}"

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -555,7 +555,7 @@ def sendStartEvaluationEvent(Map args) {
             echo "Setting localtime to ${t}"
             
             def format = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
-            def parsedtime = new SimpleDateFormat(format).parse(starttime)
+            def parsedtime = new SimpleDateFormat(format).parse(t)
             echo "Setting parsedtime to ${parsedtime}"
             
             echo "Setting starttime to ${starttime}"

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -419,10 +419,10 @@ def markEvaluationStartTime() {
     def startTime = getNow().toString()
     
     def LocalDateTime starttimelocal = LocalDateTime.now()       
-    def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));    
+    def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))    
     
     startTime = starttimeformatted
-    echo "wrtie starttime to file - ${startTime}"
+    echo "write starttime to file - ${startTime}"
     
     def keptnContextFileJson
     if (fileExists(file: getKeptnInitJsonFilename())) {
@@ -559,7 +559,7 @@ def sendStartEvaluationEvent(Map args) {
             def LocalDateTime starttimeminus = starttimelocal.minusSeconds(seconds)            
             //echo "Setting starttime minus seconds to ${t}"
             
-            def starttimeformatted = starttimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
+            def starttimeformatted = starttimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
             //echo "Setting localtime to ${t2}"
             
             starttime = starttimeformatted
@@ -581,7 +581,7 @@ def sendStartEvaluationEvent(Map args) {
             def LocalDateTime endtimeminus = endtimelocal.minusSeconds(seconds)            
             //echo "Setting endtime to ${et}"
                      
-            def endtimeformatted = endtimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
+            def endtimeformatted = endtimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
             //echo "Setting localtime to ${et2}"
             
             endtime = endtimeformatted            
@@ -595,7 +595,7 @@ def sendStartEvaluationEvent(Map args) {
         endtime = getNow().toString()
         
         def LocalDateTime endtimelocal = LocalDateTime.now()                        
-        def endtimeformatted = endtimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
+        def endtimeformatted = endtimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
         //echo "Setting localtime to ${et2}"
             
         endtime = endtimeformatted    

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -416,7 +416,7 @@ def keptnAddStageResources(file, remoteUri) {
  * Stores the current local time in keptn.input.json
  */
 def markEvaluationStartTime() {
-    def startTime = getNow().toString()
+    //def startTime = getNow().toString()
     
     def LocalDateTime starttimelocal = LocalDateTime.now()       
     def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))    
@@ -552,7 +552,7 @@ def sendStartEvaluationEvent(Map args) {
     if (starttime?.isInteger()) {
         seconds = starttime.toInteger()
         if (seconds > 0) {
-            starttime = getNow().minusSeconds((int)starttime.toInteger()).toString()
+            //starttime = getNow().minusSeconds((int)starttime.toInteger()).toString()
             //echo "Setting starttime to ${starttime}"
            
             def LocalDateTime starttimelocal = LocalDateTime.now()
@@ -574,7 +574,7 @@ def sendStartEvaluationEvent(Map args) {
     if (endtime?.isInteger()) {
         seconds = endtime.toInteger()
         if (seconds > 0) {
-            endtime = getNow().minusSeconds((int)endtime.toInteger()).toString()
+            //endtime = getNow().minusSeconds((int)endtime.toInteger()).toString()
             //echo "Setting endtime to ${endtime}"
             
             def LocalDateTime endtimelocal = LocalDateTime.now()
@@ -592,7 +592,7 @@ def sendStartEvaluationEvent(Map args) {
         }
     }
     if (endtime == "") {
-        endtime = getNow().toString()
+        //endtime = getNow().toString()
         
         def LocalDateTime endtimelocal = LocalDateTime.now()                        
         def endtimeformatted = endtimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -548,23 +548,18 @@ def sendStartEvaluationEvent(Map args) {
         seconds = starttime.toInteger()
         if (seconds > 0) {
             starttime = getNow().minusSeconds((int)starttime.toInteger()).toString()
-            echo "Setting starttime to ${starttime}"
+            //echo "Setting starttime to ${starttime}"
            
             def LocalDateTime a = LocalDateTime.now()
-            echo "Setting localtime to ${a}"
-            
-            def LocalDateTime t = a.plusSeconds(seconds)            
-            echo "Setting localtime to ${t}"
-            
-            def format = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+            def LocalDateTime t = a.minusSeconds(seconds)            
+            echo "Setting starttime minus seconds to ${t}"
             
             def t2 = t.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
-            echo "Setting localtime to ${t2}"
+            //echo "Setting localtime to ${t2}"
             
             starttime = t2
             //def parsedtime = new SimpleDateFormat(format).parse(t)
-            //echo "Setting parsedtime to ${parsedtime}"
-            
+            //echo "Setting parsedtime to ${parsedtime}"          
             echo "Setting starttime to ${starttime}"
         } else {
             echo "No negative numbers allowed for starttime!"
@@ -575,22 +570,17 @@ def sendStartEvaluationEvent(Map args) {
         seconds = endtime.toInteger()
         if (seconds > 0) {
             endtime = getNow().minusSeconds((int)endtime.toInteger()).toString()
-            echo "Setting endtime to ${endtime}"
+            //echo "Setting endtime to ${endtime}"
             
             def LocalDateTime ea = LocalDateTime.now()
-            echo "Setting localtime to ${ea}"
-            
-            def LocalDateTime et = ea.plusMinutes(seconds)            
-            echo "Setting localtime to ${et}"
-            
-            def format = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
-            
+            def LocalDateTime et = ea.minusSeconds(seconds)            
+            echo "Setting endtime to ${et}"
+                     
             def et2 = et.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
-            echo "Setting localtime to ${et2}"
+            //echo "Setting localtime to ${et2}"
             
             endtime = et2            
-            
-            
+            echo "Setting endtime to ${endtime}"         
         } else {
             echo "No negative numbers allowed for endtime!"
             return false;

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -1,7 +1,7 @@
 package sh.keptn
 
 import java.time
-import java.time.format
+import java.time.format.DateTimeFormatter
 import java.text.SimpleDateFormat 
 import org.jenkinsci.plugins.plaincredentials.StringCredentials
 import com.cloudbees.plugins.credentials.CredentialsProvider

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -1,6 +1,6 @@
 package sh.keptn
 
-import java.time
+import java.time.*
 import java.time.format.DateTimeFormatter
 import java.text.SimpleDateFormat 
 import org.jenkinsci.plugins.plaincredentials.StringCredentials

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -713,7 +713,7 @@ def waitForEvaluationDoneEvent(Map args) {
                     ignoreSslErrors: true
 
                 //The API returns a response code 404 error if the evalution done event does not exist
-                if (response.status == 404 || response.content.contains("No Keptn sh.keptn.event.evaluation.finished event found for context") ) { 
+                if (response.status == 404 || response.content.contains("No Keptn sh.keptn.event.evaluation.finished event found for context") || response.content.contains("{\"events\":[],")) {
                     sleep 10
                     return false  
                 } else {
@@ -726,7 +726,7 @@ def waitForEvaluationDoneEvent(Map args) {
         }
     }
       
-    if (evalResponse == "" || evalResponse.equalsIgnoreCase("[]") ) {
+   if (evalResponse == "" || evalResponse.contains("{\"events\":[],") ) {
         echo "Didnt receive any successful keptn evaluation results"
         if (setBuildResult) {
             // currentBuild.result = 'FAILURE'

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -419,11 +419,8 @@ def keptnAddStageResources(file, remoteUri) {
 def markEvaluationStartTime() {
     def startTime = getNow().toString()
     
-    def LocalDateTime starttimelocal = LocalDateTime.now()
-    def LocalDateTime starttimeminus = starttimelocal.minusSeconds(seconds)            
-    //echo "Setting starttime minus seconds to ${t}"
-            
-    def starttimeformatted = starttimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));    
+    def LocalDateTime starttimelocal = LocalDateTime.now()       
+    def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));    
     
     starttime = starttimeformatted
 

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -550,14 +550,14 @@ def sendStartEvaluationEvent(Map args) {
             starttime = getNow().minusSeconds((int)starttime.toInteger()).toString()
             //echo "Setting starttime to ${starttime}"
            
-            def LocalDateTime a = LocalDateTime.now()
-            def LocalDateTime t = a.minusSeconds(seconds)            
+            def LocalDateTime starttime = LocalDateTime.now()
+            def LocalDateTime starttime = starttime.minusSeconds(seconds)            
             //echo "Setting starttime minus seconds to ${t}"
             
-            def t2 = t.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
+            def starttime = starttime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
             //echo "Setting localtime to ${t2}"
             
-            starttime = t2
+            starttime = starttime
             //def parsedtime = new SimpleDateFormat(format).parse(t)
             //echo "Setting parsedtime to ${parsedtime}"          
             echo "Setting starttime to ${starttime}"
@@ -572,14 +572,14 @@ def sendStartEvaluationEvent(Map args) {
             endtime = getNow().minusSeconds((int)endtime.toInteger()).toString()
             //echo "Setting endtime to ${endtime}"
             
-            def LocalDateTime ea = LocalDateTime.now()
-            def LocalDateTime et = ea.minusSeconds(seconds)            
+            def LocalDateTime endtime = LocalDateTime.now()
+            def LocalDateTime endtime = endtime.minusSeconds(seconds)            
             //echo "Setting endtime to ${et}"
                      
-            def et2 = et.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
+            def endtime = endtime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
             //echo "Setting localtime to ${et2}"
             
-            endtime = et2            
+            endtime = endtime            
             echo "Setting endtime to ${endtime}"         
         } else {
             echo "No negative numbers allowed for endtime!"
@@ -589,11 +589,11 @@ def sendStartEvaluationEvent(Map args) {
     if (endtime == "") {
         endtime = getNow().toString()
         
-        def LocalDateTime ea = LocalDateTime.now()                        
-        def et2 = ea.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
+        def LocalDateTime endtime = LocalDateTime.now()                        
+        def endtime = endtime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
         //echo "Setting localtime to ${et2}"
             
-        endtime = et2    
+        endtime = endtime    
         echo "Endttime empty. Setting endtime to Now: ${endtime}"
     }
 

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -556,7 +556,7 @@ def sendStartEvaluationEvent(Map args) {
             
             def format = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
             
-            def t2 = localDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ"));
+            def t2 = t.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ"));
             
             echo "Setting localtime to ${t}"
             //def parsedtime = new SimpleDateFormat(format).parse(t)

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -718,7 +718,7 @@ def waitForEvaluationDoneEvent(Map args) {
                     return false  
                 } else {
                     evalResponse = response.content
-                    echo "response content: ${response}"
+                    echo "response content: ${response.content}"
                     echo "eval response: ${evalResponse}" 
                     return true
                 } 

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -550,10 +550,11 @@ def sendStartEvaluationEvent(Map args) {
            
             def LocalDateTime a = LocalDateTime.now()
             def LocalDateTime t = a.plusSeconds(seconds)
-            def newtime = t.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ"))
+            def DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+            def LocalDateTime t2 = LocalDateTime.parse(t, formatter)
             
             echo "Setting localtime to ${t}"
-            echo "Setting newtime to ${newtime}"
+            echo "Setting newtime to ${t2}"
             
             def format = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
             def parsedtime = new SimpleDateFormat(format).parse(starttime)

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -580,7 +580,7 @@ def sendStartEvaluationEvent(Map args) {
             def LocalDateTime ea = LocalDateTime.now()
             echo "Setting localtime to ${ea}"
             
-            def LocalDateTime et = ea.plusSeconds(seconds)            
+            def LocalDateTime et = ea.plusMinutes(seconds)            
             echo "Setting localtime to ${et}"
             
             def format = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -588,6 +588,12 @@ def sendStartEvaluationEvent(Map args) {
     }
     if (endtime == "") {
         endtime = getNow().toString()
+        
+        def LocalDateTime ea = LocalDateTime.now()                        
+        def et2 = et.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
+        //echo "Setting localtime to ${et2}"
+            
+        endtime = et2    
         echo "Endttime empty. Setting endtime to Now: ${endtime}"
     }
 

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -33,7 +33,7 @@ def getNow() {
     return java.time.Instant.now()
 }
 
-def dateFormatter(timestamp) {
+def timestampFormatter(timestamp) {
     def timeformatted = timestamp.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
     return timeformatted
 }    
@@ -426,7 +426,7 @@ def markEvaluationStartTime() {
     def LocalDateTime starttimelocal = LocalDateTime.now()       
     def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
     
-    def timestampformatted = dateFormatter(starttimelocal)
+    timestampformatted = timestampFormatter[starttimelocal]
     echo "new timestamp formatted: ${timestampformatted}"
     
     startTime = starttimeformatted

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -1,5 +1,6 @@
 package sh.keptn
 
+import java.text.*
 import org.jenkinsci.plugins.plaincredentials.StringCredentials
 import com.cloudbees.plugins.credentials.CredentialsProvider
 import com.cloudbees.plugins.credentials.domains.DomainRequirement

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -549,8 +549,12 @@ def sendStartEvaluationEvent(Map args) {
             starttime = getNow().minusSeconds((int)starttime.toInteger()).toString()
            
             def LocalDateTime a = LocalDateTime.now()
-            def LocalDateTime t = a.plusSeconds(seconds);
+            def LocalDateTime t = a.plusSeconds(seconds)
+            def format = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+            def newtime = t.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ"))
+            
             echo "Setting localtime to ${t}"
+            echo "Setting newtime to ${newtime}"
             
             def format = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
             def parsedtime = new SimpleDateFormat(format).parse(starttime)

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -568,7 +568,7 @@ def sendStartEvaluationEvent(Map args) {
             
             def starttimeformatted = starttimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
             
-            timestampformatted = timestampFormatter[starttimelocal]
+            timestampformatted = timestampFormatter(starttimelocal)
             echo "new timestamp formatted: ${timestampformatted}"
             
             starttime = starttimeformatted

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -1,6 +1,7 @@
 package sh.keptn
 
-import java.time.*
+import java.time
+import java.time.format
 import java.text.SimpleDateFormat 
 import org.jenkinsci.plugins.plaincredentials.StringCredentials
 import com.cloudbees.plugins.credentials.CredentialsProvider

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -2,7 +2,6 @@ package sh.keptn
 
 import java.time.*
 import java.time.format.DateTimeFormatter
-import java.text.SimpleDateFormat 
 import org.jenkinsci.plugins.plaincredentials.StringCredentials
 import com.cloudbees.plugins.credentials.CredentialsProvider
 import com.cloudbees.plugins.credentials.domains.DomainRequirement
@@ -423,7 +422,8 @@ def markEvaluationStartTime() {
     def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));    
     
     startTime = starttimeformatted
-
+    echo "wrtie starttime to file - ${startTime}"
+    
     def keptnContextFileJson
     if (fileExists(file: getKeptnInitJsonFilename())) {
         def keptnContextFileContent = readFile getKeptnInitJsonFilename()

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -718,6 +718,7 @@ def waitForEvaluationDoneEvent(Map args) {
                     return false  
                 } else {
                     evalResponse = response.content
+                    echo "response content: ${response}"
                     echo "eval response: ${evalResponse}" 
                     return true
                 } 

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -551,11 +551,8 @@ def sendStartEvaluationEvent(Map args) {
            
             def LocalDateTime a = LocalDateTime.now()
             def LocalDateTime t = a.plusSeconds(seconds)
-            def DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
-            def LocalDateTime t2 = LocalDateTime.parse(t, formatter)
             
             echo "Setting localtime to ${t}"
-            echo "Setting newtime to ${t2}"
             
             def format = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
             def parsedtime = new SimpleDateFormat(format).parse(starttime)

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -693,7 +693,7 @@ def waitForEvaluationDoneEvent(Map args) {
         }
     }
     
-    if (evalResponse.contains("troubleshooting") || response.content.equalsIgnoreCase("[]") ) {
+    if (evalResponse.contains("troubleshooting") || evalResponse.equalsIgnoreCase("[]") ) {
         echo "Received invalid keptn evaluation results"
         if (setBuildResult) {
             // currentBuild.result = 'FAILURE'

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -33,6 +33,7 @@ def getNow() {
     return java.time.Instant.now()
 }
 
+// use to format timestamps to conform with keptn
 def timestampFormatter(timestamp) {
     def timeformatted = timestamp.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
     return timeformatted
@@ -427,7 +428,7 @@ def markEvaluationStartTime() {
     //def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
     
     startTime = timestampFormatter(starttimelocal)
-    //startTime = starttimeformatted
+
     echo "write starttime to file - ${startTime}"
     
     def keptnContextFileJson
@@ -564,8 +565,6 @@ def sendStartEvaluationEvent(Map args) {
             def LocalDateTime starttimelocal = LocalDateTime.now()
             def LocalDateTime starttimeminus = starttimelocal.minusSeconds(seconds)            
             
-            //def starttimeformatted = starttimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
-            
             starttimeformatted = timestampFormatter(starttimeminus)
             
             starttime = starttimeformatted
@@ -584,8 +583,6 @@ def sendStartEvaluationEvent(Map args) {
             
             def LocalDateTime endtimelocal = LocalDateTime.now()
             def LocalDateTime endtimeminus = endtimelocal.minusSeconds(seconds)            
-                     
-            //def endtimeformatted = endtimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
             
             endtimeformatted = timestampFormatter(endtimeminus)
             
@@ -600,7 +597,6 @@ def sendStartEvaluationEvent(Map args) {
         //endtime = getNow().toString()
         
         def LocalDateTime endtimelocal = LocalDateTime.now()                        
-        //def endtimeformatted = endtimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
         
         endtimeformatted = timestampFormatter(endtimelocal)
         

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -424,12 +424,10 @@ def markEvaluationStartTime() {
     //def startTime = getNow().toString()
     
     def LocalDateTime starttimelocal = LocalDateTime.now()       
-    def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
+    //def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
     
-    timestampformatted = timestampFormatter[starttimelocal]
-    echo "new timestamp formatted: ${timestampformatted}"
-    
-    startTime = starttimeformatted
+    startTime = timestampFormatter(starttimelocal)
+    //startTime = starttimeformatted
     echo "write starttime to file - ${startTime}"
     
     def keptnContextFileJson
@@ -566,10 +564,9 @@ def sendStartEvaluationEvent(Map args) {
             def LocalDateTime starttimelocal = LocalDateTime.now()
             def LocalDateTime starttimeminus = starttimelocal.minusSeconds(seconds)            
             
-            def starttimeformatted = starttimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
+            //def starttimeformatted = starttimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
             
-            timestampformatted = timestampFormatter(starttimelocal)
-            echo "new timestamp formatted: ${timestampformatted}"
+            starttimeformatted = timestampFormatter(starttimeminus)
             
             starttime = starttimeformatted
          
@@ -588,7 +585,9 @@ def sendStartEvaluationEvent(Map args) {
             def LocalDateTime endtimelocal = LocalDateTime.now()
             def LocalDateTime endtimeminus = endtimelocal.minusSeconds(seconds)            
                      
-            def endtimeformatted = endtimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
+            //def endtimeformatted = endtimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
+            
+            endtimeformatted = timestampFormatter(endtimeminus)
             
             endtime = endtimeformatted            
             echo "Setting endtime to ${endtime}"         
@@ -601,8 +600,10 @@ def sendStartEvaluationEvent(Map args) {
         //endtime = getNow().toString()
         
         def LocalDateTime endtimelocal = LocalDateTime.now()                        
-        def endtimeformatted = endtimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
-            
+        //def endtimeformatted = endtimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
+        
+        endtimeformatted = timestampFormatter(endtimelocal)
+        
         endtime = endtimeformatted    
         echo "Endttime empty. Setting endtime to Now: ${endtime}"
     }

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -550,14 +550,14 @@ def sendStartEvaluationEvent(Map args) {
             starttime = getNow().minusSeconds((int)starttime.toInteger()).toString()
             //echo "Setting starttime to ${starttime}"
            
-            def LocalDateTime starttime = LocalDateTime.now()
-            def LocalDateTime starttime = starttime.minusSeconds(seconds)            
+            def LocalDateTime starttimelocal = LocalDateTime.now()
+            def LocalDateTime starttimeminus = starttimelocal.minusSeconds(seconds)            
             //echo "Setting starttime minus seconds to ${t}"
             
-            def starttime = starttime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
+            def starttimeformatted = starttimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
             //echo "Setting localtime to ${t2}"
             
-            starttime = starttime
+            starttime = starttimeformatted
             //def parsedtime = new SimpleDateFormat(format).parse(t)
             //echo "Setting parsedtime to ${parsedtime}"          
             echo "Setting starttime to ${starttime}"
@@ -572,14 +572,14 @@ def sendStartEvaluationEvent(Map args) {
             endtime = getNow().minusSeconds((int)endtime.toInteger()).toString()
             //echo "Setting endtime to ${endtime}"
             
-            def LocalDateTime endtime = LocalDateTime.now()
-            def LocalDateTime endtime = endtime.minusSeconds(seconds)            
+            def LocalDateTime endtimelocal = LocalDateTime.now()
+            def LocalDateTime endtimeminus = endtimelocal.minusSeconds(seconds)            
             //echo "Setting endtime to ${et}"
                      
-            def endtime = endtime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
+            def endtimeformatted = endtimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
             //echo "Setting localtime to ${et2}"
             
-            endtime = endtime            
+            endtime = endtimeformatted            
             echo "Setting endtime to ${endtime}"         
         } else {
             echo "No negative numbers allowed for endtime!"
@@ -589,11 +589,11 @@ def sendStartEvaluationEvent(Map args) {
     if (endtime == "") {
         endtime = getNow().toString()
         
-        def LocalDateTime endtime = LocalDateTime.now()                        
-        def endtime = endtime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
+        def LocalDateTime endtimelocal = LocalDateTime.now()                        
+        def endtimeformatted = endtimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
         //echo "Setting localtime to ${et2}"
             
-        endtime = endtime    
+        endtime = endtimeformatted    
         echo "Endttime empty. Setting endtime to Now: ${endtime}"
     }
 

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -552,7 +552,7 @@ def sendStartEvaluationEvent(Map args) {
            
             def LocalDateTime a = LocalDateTime.now()
             def LocalDateTime t = a.minusSeconds(seconds)            
-            echo "Setting starttime minus seconds to ${t}"
+            //echo "Setting starttime minus seconds to ${t}"
             
             def t2 = t.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
             //echo "Setting localtime to ${t2}"
@@ -574,7 +574,7 @@ def sendStartEvaluationEvent(Map args) {
             
             def LocalDateTime ea = LocalDateTime.now()
             def LocalDateTime et = ea.minusSeconds(seconds)            
-            echo "Setting endtime to ${et}"
+            //echo "Setting endtime to ${et}"
                      
             def et2 = et.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
             //echo "Setting localtime to ${et2}"

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -677,14 +677,9 @@ def waitForEvaluationDoneEvent(Map args) {
                     ignoreSslErrors: true
 
                 //The API returns a response code 404 error if the evalution done event does not exist
-                if (response.status == 404 || response.content.contains("No Keptn sh.keptn.event.evaluation.finished event found for context") ) {
-                    if (response.content.contains("troubleshooting") || response.content.equalsIgnoreCase("[]") ) {
-                        evalResponse = response.content
-                        return true
-                    } else {   
+                if (response.status == 404 || response.content.contains("No Keptn sh.keptn.event.evaluation.finished event found for context") ) { 
                     sleep 10
-                    return false
-                    }    
+                    return false  
                 } else {
                     evalResponse = response.content
                     return true
@@ -692,20 +687,8 @@ def waitForEvaluationDoneEvent(Map args) {
             }
         }
     }
-    
-    if (evalResponse.contains("troubleshooting") || evalResponse.equalsIgnoreCase("[]") ) {
-        echo "Received invalid keptn evaluation results"
-        if (setBuildResult) {
-            // currentBuild.result = 'FAILURE'
-            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                error("Didnt receive a proper keptn evaluation result")
-                // sh "exit 1"
-            }
-        }
-        return false;
-    } 
-    
-    if (evalResponse == "") {
+      
+    if (evalResponse == "" || evalResponse.contains("troubleshooting") || evalResponse.equalsIgnoreCase("[]") {
         echo "Didnt receive any successful keptn evaluation results"
         if (setBuildResult) {
             // currentBuild.result = 'FAILURE'

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -2,6 +2,7 @@ package sh.keptn
 
 import java.time.LocalDateTime; // Import the LocalDateTime class
 import java.time.format.DateTimeFormatter; // Import the DateTimeFormatter class
+import java.text.SimpleDateFormat 
 import org.jenkinsci.plugins.plaincredentials.StringCredentials
 import com.cloudbees.plugins.credentials.CredentialsProvider
 import com.cloudbees.plugins.credentials.domains.DomainRequirement

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -643,7 +643,7 @@ def sendStartEvaluationEvent(Map args) {
         |  "datacontenttype": "application/json",        
         |  "source": "Jenkins",
         |  "specversion": "1.0",
-        |  "type": "sh.keptn.event.evaluation.triggered"
+        |  "type": "sh.keptn.event.${stage}.evaluation.triggered"
         |}
     """.stripMargin()
 

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -546,7 +546,7 @@ def sendStartEvaluationEvent(Map args) {
         seconds = starttime.toInteger()
         if (seconds > 0) {
             starttime = getNow().minusSeconds((int)starttime.toInteger()).toString()
-            def format = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+            def format = "yyyy-MM-dd'T'HH:mm:ss.SSS"
             def parsedtime = new SimpleDateFormat(format).parse(starttime)
             echo "Setting parsedtime to ${parsedtime}"
             echo "Setting starttime to ${starttime}"

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -705,7 +705,8 @@ def waitForEvaluationDoneEvent(Map args) {
             waitUntil {
                 // Post the Keptn Context to the Keptn api to get the Evaluation-done event
                 def response = httpRequest contentType: 'APPLICATION_JSON', 
-                    customHeaders: [[maskValue: true, name: 'x-token', value: "${keptn_api_token}", name: 'application/json', value: 'application/json']], 
+                    customHeaders: [[maskValue: true, name: 'x-token', value: "${keptn_api_token}"]],
+                    customHeaders: [[maskValue: false, name: 'accept', value: "application/json"]],
                     httpMode: 'GET', 
                     responseHandle: 'STRING', 
                     url: "${keptn_endpoint}/mongodb-datastore/event?keptnContext=${keptn_context}&type=sh.keptn.event.evaluation.finished&pageSize=20", 

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -688,7 +688,7 @@ def waitForEvaluationDoneEvent(Map args) {
         }
     }
       
-    if (evalResponse == "" || evalResponse.contains("troubleshooting") || evalResponse.equalsIgnoreCase("[]") ) {
+    if (evalResponse == "" || evalResponse.equalsIgnoreCase("[]") ) {
         echo "Didnt receive any successful keptn evaluation results"
         if (setBuildResult) {
             // currentBuild.result = 'FAILURE'

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -705,7 +705,7 @@ def waitForEvaluationDoneEvent(Map args) {
             waitUntil {
                 // Post the Keptn Context to the Keptn api to get the Evaluation-done event
                 def response = httpRequest contentType: 'APPLICATION_JSON', 
-                    customHeaders: [[maskValue: true, name: 'x-token', value: "${keptn_api_token}"]], 
+                    customHeaders: [[maskValue: true, name: 'x-token', value: "${keptn_api_token}", name: 'application/json', value: 'application/json']], 
                     httpMode: 'GET', 
                     responseHandle: 'STRING', 
                     url: "${keptn_endpoint}/mongodb-datastore/event?keptnContext=${keptn_context}&type=sh.keptn.event.evaluation.finished&pageSize=20", 

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -718,6 +718,7 @@ def waitForEvaluationDoneEvent(Map args) {
                     return false  
                 } else {
                     evalResponse = response.content
+                    echo "eval response: ${evalResponse}" 
                     return true
                 } 
             }

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -557,7 +557,7 @@ def sendStartEvaluationEvent(Map args) {
             
             def format = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
             
-            def t2 = t.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS"));
+            def t2 = t.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
             echo "Setting localtime to ${t2}"
             
             //def parsedtime = new SimpleDateFormat(format).parse(t)

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -718,7 +718,6 @@ def waitForEvaluationDoneEvent(Map args) {
                     return false  
                 } else {
                     evalResponse = response.content
-                    echo "response content: ${response.content}"
                     echo "eval response: ${evalResponse}" 
                     return true
                 } 

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -697,7 +697,7 @@ def waitForEvaluationDoneEvent(Map args) {
     }
 
     echo "Wait for Evaluation Done for keptnContext: ${keptn_context}"
-    sleep 10 //added delay for keptn that is too fast
+    sleep 20 //added delay for keptn that is too fast
     
     def evalResponse = ""
     timeout(time: waitTime, unit: 'MINUTES') {

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -706,7 +706,6 @@ def waitForEvaluationDoneEvent(Map args) {
                 // Post the Keptn Context to the Keptn api to get the Evaluation-done event
                 def response = httpRequest contentType: 'APPLICATION_JSON', 
                     customHeaders: [[maskValue: true, name: 'x-token', value: "${keptn_api_token}"]],
-                    customHeaders: [[maskValue: false, name: 'accept', value: "application/json"]],
                     httpMode: 'GET', 
                     responseHandle: 'STRING', 
                     url: "${keptn_endpoint}/mongodb-datastore/event?keptnContext=${keptn_context}&type=sh.keptn.event.evaluation.finished&pageSize=20", 

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -549,7 +549,7 @@ def sendStartEvaluationEvent(Map args) {
         if (seconds > 0) {
             starttime = getNow().minusSeconds((int)starttime.toInteger()).toString()
             
-            DateTimeFormatter myFormatObj = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+            DateTimeFormatter myFormatObj = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS")
             String formattedDate = starttime.format(myFormatObj);
              echo "Setting formatted date to ${formattedDate}"
             


### PR DESCRIPTION
**Description:**
Added formatting for starttime and endtime and corrected validation check and corrected evaluation trigger.

Now using:
import java.time.*
import java.time.format.DateTimeFormatter
To impose formatting on the starttime and endtime for Keptn.

**Changes:**
- Date format added for starttime and endtime
- changed to comport with the validation checks around the returned response payload.
- corrected sh.keptn.event.${stage}.evaluation.triggered to have {stage} 
- added echo for eval response to see this in jenkins console

**TODO:** clean up code comments.

