### PR TITLE
Timestamp and Timezone additions.

### DIFF
--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -439,7 +439,7 @@ def markEvaluationStartTime() {
     //def startTime = getNow().toString()
     defineGlobalVariable()
     
-    def LocalDateTime starttimelocal = LocalDateTime.now(zid)       
+    def LocalDateTime starttimelocal = LocalDateTime.now()       
     //def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
     
     startTime = timestampFormatter(starttimelocal)
@@ -541,8 +541,7 @@ def addCustomLabels(requestBody, labels) {
  */
 def sendStartEvaluationEvent(Map args) {
     def keptnInit = keptnLoadFromInit(args)
-    defineGlobalVariable()
-    
+        
     /* String project, String stage, String service, String deploymentURI, String testStrategy */
     String keptn_endpoint = keptnInit['keptn_endpoint']
     String keptn_api_token = keptnInit['keptn_api_token']
@@ -577,6 +576,7 @@ def sendStartEvaluationEvent(Map args) {
         if (seconds > 0) {
             //starttime = getNow().minusSeconds((int)starttime.toInteger()).toString()
             //echo "Setting starttime to ${starttime}"
+            defineGlobalVariable()
             
             def LocalDateTime starttimelocal = LocalDateTime.now(zid)
             def LocalDateTime starttimeminus = starttimelocal.minusSeconds(seconds)            
@@ -597,7 +597,7 @@ def sendStartEvaluationEvent(Map args) {
             //endtime = getNow().minusSeconds((int)endtime.toInteger()).toString()
             //echo "Setting endtime to ${endtime}"
             
-            def LocalDateTime endtimelocal = LocalDateTime.now(zid)
+            def LocalDateTime endtimelocal = LocalDateTime.now()
             def LocalDateTime endtimeminus = endtimelocal.minusSeconds(seconds)            
             
             endtimeformatted = timestampFormatter(endtimeminus)
@@ -612,7 +612,7 @@ def sendStartEvaluationEvent(Map args) {
     if (endtime == "") {
         //endtime = getNow().toString()
         
-        def LocalDateTime endtimelocal = LocalDateTime.now(zid)                        
+        def LocalDateTime endtimelocal = LocalDateTime.now()                        
         
         endtimeformatted = timestampFormatter(endtimelocal)
         

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -27,7 +27,7 @@ def downloadFile(url, file) {
 def getKeptnContextJsonFilename() {return "keptn.context.${BUILD_NUMBER}.json"}
 def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
 
-def defineGlobalVariable() {
+def defineTZVariable() {
         // create a clock
         def zid = ZoneId.of("America/New_York");
   
@@ -42,8 +42,10 @@ def defineGlobalVariable() {
 
 // added getNow() to easily switch between java.time.LocalDateTime.now() to Instant.now(). INstant.now() returns time in UTC where LocalDataTime returns local time without timezone. this leads to problems in case Jenkins Server and Keptn are in differnet timezones
 def getNow() {
+    // get timezone.
+    zid = defineTZVariable()
     // return java.time.LocalDateTime.now() 
-    return java.time.Instant.now()
+    return java.time.Instant.now(zid)
 }
 
 // use to format timestamps to conform with keptn
@@ -435,9 +437,10 @@ def keptnAddStageResources(file, remoteUri) {
  * Stores the current local time in keptn.input.json
  */
 def markEvaluationStartTime() {
-    //def startTime = getNow().toString()
-        
-    def LocalDateTime starttimelocal = LocalDateTime.now()       
+    // get timezone.
+    zid = defineTZVariable()
+    //def startTime = getNow().toString()       
+    def LocalDateTime starttimelocal = LocalDateTime.now(zid)       
     //def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
     
     startTime = timestampFormatter(starttimelocal)
@@ -539,6 +542,7 @@ def addCustomLabels(requestBody, labels) {
  */
 def sendStartEvaluationEvent(Map args) {
     def keptnInit = keptnLoadFromInit(args)
+    zid = defineTZVariable()
         
     /* String project, String stage, String service, String deploymentURI, String testStrategy */
     String keptn_endpoint = keptnInit['keptn_endpoint']
@@ -574,7 +578,6 @@ def sendStartEvaluationEvent(Map args) {
         if (seconds > 0) {
             //starttime = getNow().minusSeconds((int)starttime.toInteger()).toString()
             //echo "Setting starttime to ${starttime}"
-            zid = defineGlobalVariable()
             
             def LocalDateTime starttimelocal = LocalDateTime.now(zid)
             def LocalDateTime starttimeminus = starttimelocal.minusSeconds(seconds)            
@@ -595,7 +598,7 @@ def sendStartEvaluationEvent(Map args) {
             //endtime = getNow().minusSeconds((int)endtime.toInteger()).toString()
             //echo "Setting endtime to ${endtime}"
             
-            def LocalDateTime endtimelocal = LocalDateTime.now()
+            def LocalDateTime endtimelocal = LocalDateTime.now(zid)
             def LocalDateTime endtimeminus = endtimelocal.minusSeconds(seconds)            
             
             endtimeformatted = timestampFormatter(endtimeminus)
@@ -610,7 +613,7 @@ def sendStartEvaluationEvent(Map args) {
     if (endtime == "") {
         //endtime = getNow().toString()
         
-        def LocalDateTime endtimelocal = LocalDateTime.now()                        
+        def LocalDateTime endtimelocal = LocalDateTime.now(zid)                        
         
         endtimeformatted = timestampFormatter(endtimelocal)
         

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -188,7 +188,8 @@ def keptnInit(Map args) {
             responseHandle: 'STRING', 
             url: "${keptn_endpoint}/controlPlane/v1/project", 
             validResponseCodes: "100:404",
-            ignoreSslErrors: true
+            ignoreSslErrors: true,
+            quiet: true
 
         //echo "project body: ${createProjectBody}"
         
@@ -223,7 +224,8 @@ def keptnInit(Map args) {
             responseHandle: 'STRING', 
             url: "${keptn_endpoint}/controlPlane/v1/project/${project}/service", 
             validResponseCodes: "100:404",
-            ignoreSslErrors: true
+            ignoreSslErrors: true,
+            quiet: true
         
         if (createServiceResponse.status == 200) {
             echo "Created new Keptn Service: ${service}"
@@ -253,7 +255,8 @@ def keptnInit(Map args) {
                 responseHandle: 'STRING', 
                 url: "${keptn_endpoint}/v1/event", 
                 validResponseCodes: "100:404",
-                ignoreSslErrors: true
+                ignoreSslErrors: true,
+                quiet: true
 
             if (configureMonitoringResponse.status == 200) {
                 echo "Successfully configured monitoring for: ${monitoring}"
@@ -279,7 +282,8 @@ def keptnProjectExists(Map args) {
         responseHandle: 'STRING', 
         url: "${keptnInit['keptn_endpoint']}/controlPlane/v1/project/${keptnInit['project']}", 
         validResponseCodes: "100:404",
-        ignoreSslErrors: true
+        ignoreSslErrors: true,
+        quiet: true
 
     echo "Response from get project: " + getProjectResponse.content
     if(getProjectResponse.content != "null") {
@@ -298,7 +302,8 @@ def keptnProjectStageExists(Map args) {
         responseHandle: 'STRING', 
         url: "${keptnInit['keptn_endpoint']}/controlPlane/v1/project/${keptnInit['project']}/stage/${keptnInit['stage']}", 
         validResponseCodes: "100:404",
-        ignoreSslErrors: true
+        ignoreSslErrors: true,
+        quiet: true
 
     echo "Response from get project stage: " + getProjectStageResponse.content
 
@@ -316,7 +321,8 @@ def keptnProjectServiceExists(Map args) {
         responseHandle: 'STRING', 
         url: "${keptnInit['keptn_endpoint']}/controlPlane/v1/project/${keptnInit['project']}/stage/${keptnInit['stage']}/service/${keptnInit['service']}", 
         validResponseCodes: "100:404",
-        ignoreSslErrors: true
+        ignoreSslErrors: true,
+        quiet: true
 
     echo "Response from get project service: " + getProjectServiceResponse.content
 
@@ -335,7 +341,8 @@ def keptnDeleteProject(Map args) {
         responseHandle: 'STRING', 
         url: "${keptnInit['keptn_endpoint']}/configuration-service/v1/project/${keptnInit['project']}", 
         validResponseCodes: "100:404",
-        ignoreSslErrors: true
+        ignoreSslErrors: true,
+        quiet: true
 
     echo "Response from delete project: " + deleteProjectResponse.content
 }
@@ -366,7 +373,8 @@ def keptnAddResources(file, remoteUri) {
             responseHandle: 'STRING', 
             url: "${keptnInit['keptn_endpoint']}/configuration-service/v1/project/${keptnInit['project']}/stage/${keptnInit['stage']}/service/${keptnInit['service']}/resource", 
             validResponseCodes: "100:404",
-            ignoreSslErrors: true
+            ignoreSslErrors: true,
+            quiet: true
 
         echo "Response from upload resource ${file} to ${remoteUri}: " + addResourceResponse.content
 
@@ -400,7 +408,8 @@ def keptnAddProjectResources(file, remoteUri) {
             responseHandle: 'STRING', 
             url: "${keptnInit['keptn_endpoint']}/configuration-service/v1/project/${keptnInit['project']}/resource", 
             validResponseCodes: "100:404",
-            ignoreSslErrors: true
+            ignoreSslErrors: true,
+            quiet: true
 
         echo "Response from upload resource ${file} to ${remoteUri}: " + addResourceResponse.content
 
@@ -434,7 +443,8 @@ def keptnAddStageResources(file, remoteUri) {
             responseHandle: 'STRING', 
             url: "${keptnInit['keptn_endpoint']}/configuration-service/v1/project/${keptnInit['project']}/stage/${keptnInit['stage']}/resource", 
             validResponseCodes: "100:404",
-            ignoreSslErrors: true
+            ignoreSslErrors: true,
+            quiet: true
 
         echo "Response from upload resource ${file} to ${remoteUri}: " + addResourceResponse.content
 
@@ -689,7 +699,8 @@ def sendStartEvaluationEvent(Map args) {
       responseHandle: 'STRING', 
       url: "${keptn_endpoint}/v1/event", 
       validResponseCodes: "100:404", 
-      ignoreSslErrors: true
+      ignoreSslErrors: true,
+      quiet: true
 
     // write response to keptn.context.json & add to artifacts
     def keptnContext = writeKeptnContextFiles(response)
@@ -742,7 +753,8 @@ def waitForEvaluationDoneEvent(Map args) {
                     responseHandle: 'STRING', 
                     url: "${keptn_endpoint}/mongodb-datastore/event?keptnContext=${keptn_context}&type=sh.keptn.event.evaluation.finished&pageSize=20", 
                     validResponseCodes: "100:404", 
-                    ignoreSslErrors: true
+                    ignoreSslErrors: true,
+                    quiet: true
 
                 //The API returns a response code 404 error if the evalution done event does not exist
                 if (response.status == 404 || response.content.contains("No Keptn sh.keptn.event.evaluation.finished event found for context") || response.content.contains("{\"events\":[],")) {
@@ -881,7 +893,8 @@ def sendDeploymentFinishedEvent(Map args) {
       responseHandle: 'STRING', 
       url: "${keptn_endpoint}/v1/event", 
       validResponseCodes: "100:404", 
-      ignoreSslErrors: true
+      ignoreSslErrors: true,
+      quiet: true
 
     // write response to keptn.context.json & add to artifacts
     def keptnContext = writeKeptnContextFiles(response)
@@ -954,7 +967,8 @@ def sendDeploymentTriggeredEvent(Map args) {
       responseHandle: 'STRING', 
       url: "${keptn_endpoint}/v1/event", 
       validResponseCodes: "100:404", 
-      ignoreSslErrors: true
+      ignoreSslErrors: true,
+      quiet: true
 
     // write response to keptn.context.json & add to artifacts
     def keptnContext = writeKeptnContextFiles(response)
@@ -1027,7 +1041,8 @@ def sendTestTriggeredEvent(Map args) {
       responseHandle: 'STRING', 
       url: "${keptn_endpoint}/v1/event", 
       validResponseCodes: "100:404", 
-      ignoreSslErrors: true
+      ignoreSslErrors: true,
+      quiet: true  
 
 
     // write response to keptn.context.json & add to artifacts
@@ -1096,7 +1111,8 @@ def sendConfigurationChangedEvent(Map args) {
       responseHandle: 'STRING', 
       url: "${keptn_endpoint}/v1/event", 
       validResponseCodes: "100:404", 
-      ignoreSslErrors: true
+      ignoreSslErrors: true,
+      quiet: true
 
 
     // write response to keptn.context.json & add to artifacts
@@ -1171,7 +1187,8 @@ def sendConfigurationTriggeredEvent(Map args) {
       responseHandle: 'STRING', 
       url: "${keptn_endpoint}/v1/event", 
       validResponseCodes: "100:404", 
-      ignoreSslErrors: true
+      ignoreSslErrors: true,
+      quiet: true
 
     // write response to keptn.context.json & add to artifacts
     def keptnContext = writeKeptnContextFiles(response)

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -568,6 +568,9 @@ def sendStartEvaluationEvent(Map args) {
             
             def starttimeformatted = starttimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
             
+            timestampformatted = timestampFormatter[starttimelocal]
+            echo "new timestamp formatted: ${timestampformatted}"
+            
             starttime = starttimeformatted
          
             echo "Setting starttime to ${starttime}"

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -28,9 +28,16 @@ def getKeptnContextJsonFilename() {return "keptn.context.${BUILD_NUMBER}.json"}
 def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
 
 // set the timezone
-def defineTZVariable() {
+def defineTZVariable(Map args) {
+
+		String timezone = args.containsKey("timezone") ? args.timezone : ""
+		
+		if ((timezone == "")) {
+        timezone = "Etc/UTC"
+        }
+        
         timezone = "America/New_York"
-        //timezone = "Etc/UTC"
+        
         
         def zid = ZoneId.of(timezone);
   

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -31,15 +31,15 @@ def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
 def defineTZVariable(timezone) {
 
     if (timezone == null) {
-      timezone = "Etc/UTC"       
+      timezone = "Etc/UTC"
+      def zid = ZoneId.of(timezone)
+      LocalDateTime lt = LocalDateTime.now(zid)       
     } else {
    	  timezone = timezone
+   	  def zid = ZoneId.of(timezone)
+   	  LocalDateTime lt = LocalDateTime.now(zid);
     }
-        
-    def zid = ZoneId.of(timezone);
-  
-    // create an LocalDateTime object using now(zoneId)
-    LocalDateTime lt = LocalDateTime.now(zid);
+
     echo "TZ: ${timezone}"
     return zid
 }

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -27,6 +27,11 @@ def downloadFile(url, file) {
 
 def getKeptnContextJsonFilename() {return "keptn.context.${BUILD_NUMBER}.json"}
 def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
+
+def verbose() {
+    verbose = "false"
+    return verbose
+}
 /**
 * set the timezone
 * uses Jenkins timezone format denoted here https://gist.github.com/JinnaBalu/d630c37ef1f87cfcfa622c3a4e77d78c
@@ -276,7 +281,8 @@ def keptnInit(Map args) {
  */
 def keptnProjectExists(Map args) {
     def keptnInit = keptnLoadFromInit(args)
-    def verbose="false"
+    
+    verbose=verbose()
     
     def getProjectResponse = httpRequest customHeaders: [[maskValue: true, name: 'x-token', value: "${keptnInit['keptn_api_token']}"]], 
         httpMode: 'GET', 
@@ -300,7 +306,8 @@ def keptnProjectExists(Map args) {
  */
 def keptnProjectStageExists(Map args) {
     def keptnInit = keptnLoadFromInit(args)
-    def verbose="false"
+   
+    verbose=verbose()
     
     def getProjectStageResponse = httpRequest customHeaders: [[maskValue: true, name: 'x-token', value: "${keptnInit['keptn_api_token']}"]], 
         httpMode: 'GET', 
@@ -322,7 +329,8 @@ def keptnProjectStageExists(Map args) {
  */
 def keptnProjectServiceExists(Map args) {
     def keptnInit = keptnLoadFromInit(args)
-    def verbose="false"
+    
+    verbose=verbose()
     
     def getProjectServiceResponse = httpRequest customHeaders: [[maskValue: true, name: 'x-token', value: "${keptnInit['keptn_api_token']}"]], 
         httpMode: 'GET', 
@@ -344,7 +352,8 @@ def keptnProjectServiceExists(Map args) {
  */
 def keptnDeleteProject(Map args) {
     def keptnInit = keptnLoadFromInit(args)
-    def verbose="false"
+    
+    verbose=verbose()
     
     def deleteProjectResponse = httpRequest contentType: 'APPLICATION_JSON', 
         customHeaders: [[maskValue: true, name: 'x-token', value: "${keptnInit['keptn_api_token']}"]], 
@@ -726,7 +735,7 @@ def sendStartEvaluationEvent(Map args) {
 def waitForEvaluationDoneEvent(Map args) {
     def keptnInit = keptnLoadFromInit(args)
     
-    def verbose="false"
+    verbose=verbose()
     
     Boolean setBuildResult = args.containsKey("setBuildResult") ? args.setBuildResult : false 
     int waitTime = args.containsKey("waitTime") ? args.waitTime : 3 // default is 3 minute wait 

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -33,6 +33,11 @@ def getNow() {
     return java.time.Instant.now()
 }
 
+def dateFormatter(timestamp) {
+    def timeformatted = timestamp.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
+    return timeformatted
+}    
+
 String getKeptnApiToken() {
     String keptn_api_token = env.KEPTN_API_TOKEN
     if (keptn_api_token == null) {
@@ -419,7 +424,10 @@ def markEvaluationStartTime() {
     //def startTime = getNow().toString()
     
     def LocalDateTime starttimelocal = LocalDateTime.now()       
-    def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))    
+    def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
+    
+    def timestampformatted = dateFormatter(starttimelocal)
+    echo "new timestamp formatted: ${timestampformatted}"
     
     startTime = starttimeformatted
     echo "write starttime to file - ${startTime}"
@@ -557,14 +565,11 @@ def sendStartEvaluationEvent(Map args) {
            
             def LocalDateTime starttimelocal = LocalDateTime.now()
             def LocalDateTime starttimeminus = starttimelocal.minusSeconds(seconds)            
-            //echo "Setting starttime minus seconds to ${t}"
             
             def starttimeformatted = starttimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
-            //echo "Setting localtime to ${t2}"
             
             starttime = starttimeformatted
-            //def parsedtime = new SimpleDateFormat(format).parse(t)
-            //echo "Setting parsedtime to ${parsedtime}"          
+         
             echo "Setting starttime to ${starttime}"
         } else {
             echo "No negative numbers allowed for starttime!"
@@ -579,10 +584,8 @@ def sendStartEvaluationEvent(Map args) {
             
             def LocalDateTime endtimelocal = LocalDateTime.now()
             def LocalDateTime endtimeminus = endtimelocal.minusSeconds(seconds)            
-            //echo "Setting endtime to ${et}"
                      
             def endtimeformatted = endtimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
-            //echo "Setting localtime to ${et2}"
             
             endtime = endtimeformatted            
             echo "Setting endtime to ${endtime}"         
@@ -596,7 +599,6 @@ def sendStartEvaluationEvent(Map args) {
         
         def LocalDateTime endtimelocal = LocalDateTime.now()                        
         def endtimeformatted = endtimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
-        //echo "Setting localtime to ${et2}"
             
         endtime = endtimeformatted    
         echo "Endttime empty. Setting endtime to Now: ${endtime}"

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -50,10 +50,10 @@ def timestampFormatter(timestamp) {
 }    
 
 // added getNow() to easily switch between java.time.LocalDateTime.now() to Instant.now(). INstant.now() returns time in UTC where LocalDataTime returns local time without timezone. this leads to problems in case Jenkins Server and Keptn are in differnet timezones
+// This function has been deprecated and replaced with the the defineTZVariable and timestampFormatter functions
 def getNow() {
     // get timezone.
     def keptnInit = keptnLoadFromInit(args)
-    
     String timezone = keptnInit['timezone']
     zid = defineTZVariable(timezone)
     // return java.time.LocalDateTime.now() 
@@ -444,9 +444,7 @@ def keptnAddStageResources(file, remoteUri) {
  * Stores the current local time in keptn.input.json
  */
 def markEvaluationStartTime(timezone) {
-    // get timezone.  
-    echo "TZ: ${timezone}"
-    
+    // get timezone.     
     zid = defineTZVariable(timezone)
     //def startTime = getNow().toString()       
     def LocalDateTime starttimelocal = LocalDateTime.now(zid)       

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -30,8 +30,6 @@ def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
 // set the timezone
 def defineTZVariable(timezone) {
 
-    echo "timezone: ${timezone}"
-
     if (timezone == null) {
       timezone = "Etc/UTC"       
     } else {
@@ -42,10 +40,7 @@ def defineTZVariable(timezone) {
   
     // create an LocalDateTime object using now(zoneId)
     LocalDateTime lt = LocalDateTime.now(zid);
-  
-    // print result
-    echo "LocalDateTime : ${lt}"
-    echo "TZ: ${zid}"
+
     return zid
 }
 
@@ -449,11 +444,9 @@ def keptnAddStageResources(file, remoteUri) {
 /** 
  * Stores the current local time in keptn.input.json
  */
-def markEvaluationStartTime() {
-    // get timezone.
-    def keptnInit = keptnLoadFromInit(args)
-    
-    String timezone = keptnInit['timezone']
+def markEvaluationStartTime(timezone) {
+    // get timezone.  
+    String timezone = timezone
     zid = defineTZVariable(timezone)
     //def startTime = getNow().toString()       
     def LocalDateTime starttimelocal = LocalDateTime.now(zid)       

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -26,7 +26,7 @@ def downloadFile(url, file) {
 
 def getKeptnContextJsonFilename() {return "keptn.context.${BUILD_NUMBER}.json"}
 def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
-def timezone = "America/New_York"
+timezone = "America/New_York"
 
 // set the timezone
 def defineTZVariable(timezone) {

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -26,12 +26,11 @@ def downloadFile(url, file) {
 
 def getKeptnContextJsonFilename() {return "keptn.context.${BUILD_NUMBER}.json"}
 def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
-timezone = "America/New_York"
 
 // set the timezone
-def defineTZVariable(timezone) {
+def defineTZVariable() {
         // create a clock
-        timezone = timezone
+        timezone = "America/New_York"
         
         def zid = ZoneId.of(timezone);
   
@@ -53,7 +52,7 @@ def timestampFormatter(timestamp) {
 // added getNow() to easily switch between java.time.LocalDateTime.now() to Instant.now(). INstant.now() returns time in UTC where LocalDataTime returns local time without timezone. this leads to problems in case Jenkins Server and Keptn are in differnet timezones
 def getNow() {
     // get timezone.
-    zid = defineTZVariable(timezone)
+    zid = defineTZVariable()
     // return java.time.LocalDateTime.now() 
     return java.time.Instant.now(zid)
 }
@@ -440,9 +439,9 @@ def keptnAddStageResources(file, remoteUri) {
 /** 
  * Stores the current local time in keptn.input.json
  */
-def markEvaluationStartTime(timezone) {
+def markEvaluationStartTime() {
     // get timezone.
-    zid = defineTZVariable(timezone)
+    zid = defineTZVariable()
     //def startTime = getNow().toString()       
     def LocalDateTime starttimelocal = LocalDateTime.now(zid)       
     //def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
@@ -544,9 +543,9 @@ def addCustomLabels(requestBody, labels) {
  * Timeframe from Now()-11minutes to Now()-1min: starttime=660, endtime=60
  * From starttime untile now: starttime="2020-04-17T11:30:00.000Z", endtime=""
  */
-def sendStartEvaluationEvent(Map args, timezone) {
+def sendStartEvaluationEvent(Map args) {
     def keptnInit = keptnLoadFromInit(args)
-    zid = defineTZVariable(timezone)
+    zid = defineTZVariable()
         
     /* String project, String stage, String service, String deploymentURI, String testStrategy */
     String keptn_endpoint = keptnInit['keptn_endpoint']

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -30,23 +30,23 @@ def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
 // set the timezone
 def defineTZVariable(timezone) {
 
-		echo "timezone: ${timezone}"
+    echo "timezone: ${timezone}"
 
-		if (timezone == null) {
-        	timezone = "Etc/UTC"       
-        } else {
-        	timezone = timezone
-        }
+    if (timezone == null) {
+      timezone = "Etc/UTC"       
+    } else {
+   	  timezone = timezone
+    }
         
-        def zid = ZoneId.of(timezone);
+    def zid = ZoneId.of(timezone);
   
-        // create an LocalDateTime object using now(zoneId)
-        LocalDateTime lt = LocalDateTime.now(zid);
+    // create an LocalDateTime object using now(zoneId)
+    LocalDateTime lt = LocalDateTime.now(zid);
   
-        // print result
-        echo "LocalDateTime : ${lt}"
-        echo "TZ: ${zid}"
-        return zid
+    // print result
+    echo "LocalDateTime : ${lt}"
+    echo "TZ: ${zid}"
+    return zid
 }
 
 // use to format timestamps to conform with keptn

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -39,6 +39,7 @@ def defineTZVariable(timezone) {
     }
 
     echo "TZ: ${timezone}"
+    echo "ZID: ${zid}"
     return zid
 }
 

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -31,6 +31,7 @@ def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
 def defineTZVariable(timezone) {
 
     if (timezone == null || timezone == "") {
+      // use to set default timezone
       timezone = "UTC"     
     } else {
    	  timezone = timezone

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -440,7 +440,7 @@ def keptnAddStageResources(file, remoteUri) {
 /** 
  * Stores the current local time in keptn.input.json
  */
-def markEvaluationStartTime() {
+def markEvaluationStartTime(timezone) {
     // get timezone.
     zid = defineTZVariable(timezone)
     //def startTime = getNow().toString()       
@@ -544,7 +544,7 @@ def addCustomLabels(requestBody, labels) {
  * Timeframe from Now()-11minutes to Now()-1min: starttime=660, endtime=60
  * From starttime untile now: starttime="2020-04-17T11:30:00.000Z", endtime=""
  */
-def sendStartEvaluationEvent(Map args) {
+def sendStartEvaluationEvent(Map args, timezone) {
     def keptnInit = keptnLoadFromInit(args)
     zid = defineTZVariable(timezone)
         

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -7,6 +7,14 @@ import com.cloudbees.plugins.credentials.CredentialsProvider
 import com.cloudbees.plugins.credentials.domains.DomainRequirement
 
 
+/** 
+Set verbose true or false
+*/
+def verbose() {
+    verbose = "false"
+    return verbose
+}
+
 /**
  * Downloads a file from the given url and stores it in the local workspace
  */
@@ -27,11 +35,6 @@ def downloadFile(url, file) {
 
 def getKeptnContextJsonFilename() {return "keptn.context.${BUILD_NUMBER}.json"}
 def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
-
-def verbose() {
-    verbose = "false"
-    return verbose
-}
 /**
 * set the timezone
 * uses Jenkins timezone format denoted here https://gist.github.com/JinnaBalu/d630c37ef1f87cfcfa622c3a4e77d78c

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -574,9 +574,9 @@ def sendStartEvaluationEvent(Map args) {
         if (seconds > 0) {
             //starttime = getNow().minusSeconds((int)starttime.toInteger()).toString()
             //echo "Setting starttime to ${starttime}"
-            defineGlobalVariable()
+            zid = defineGlobalVariable()
             
-            def LocalDateTime starttimelocal = LocalDateTime.now()
+            def LocalDateTime starttimelocal = LocalDateTime.now(zid)
             def LocalDateTime starttimeminus = starttimelocal.minusSeconds(seconds)            
             
             starttimeformatted = timestampFormatter(starttimeminus)

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -446,7 +446,6 @@ def keptnAddStageResources(file, remoteUri) {
  */
 def markEvaluationStartTime(timezone) {
     // get timezone.  
-    String timezone = timezone
     zid = defineTZVariable(timezone)
     //def startTime = getNow().toString()       
     def LocalDateTime starttimelocal = LocalDateTime.now(zid)       

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -38,7 +38,6 @@ def defineTZVariable(timezone) {
 
     def zid = ZoneId.of(timezone)
     
-    echo "TZ: ${timezone}"
     echo "ZID: ${zid}"
     return zid
 }

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -558,8 +558,8 @@ def addCustomLabels(requestBody, labels) {
  */
 def sendStartEvaluationEvent(Map args) {
     def keptnInit = keptnLoadFromInit(args)
-    
-    String timezone = keptnInit['timezone'] 
+     
+    String timezone = args.containsKey("timezone") ? args.timezone : ""
     zid = defineTZVariable(timezone)
         
     /* String project, String stage, String service, String deploymentURI, String testStrategy */

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -31,7 +31,7 @@ def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
 def defineTZVariable(timezone) {
 
     if (timezone == null || timezone == "") {
-      timezone = "Etc/UTC"
+      timezone = "UTC"
       def zid = ZoneId.of(timezone)      
     } else {
    	  timezone = timezone

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -27,10 +27,21 @@ def downloadFile(url, file) {
 def getKeptnContextJsonFilename() {return "keptn.context.${BUILD_NUMBER}.json"}
 def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
 
-def defineGlobalVariable() {
-    // create a clock
-    ZoneId zid = ZoneId.of("America/New_York");
-    echo "TimeZone: ${zid}"
+public class GFG {
+    public static void main(String[] args)
+    {
+  
+        // create a clock
+        ZoneId zid = ZoneId.of("Europe/Paris");
+  
+        // create an LocalDateTime object using now(zoneId)
+        LocalDateTime lt
+            = LocalDateTime.now(zid);
+  
+        // print result
+        System.out.println("LocalDateTime : "
+                           + lt);
+    }
 }
 
 // added getNow() to easily switch between java.time.LocalDateTime.now() to Instant.now(). INstant.now() returns time in UTC where LocalDataTime returns local time without timezone. this leads to problems in case Jenkins Server and Keptn are in differnet timezones

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -38,8 +38,6 @@ def defineGlobalVariable() {
         System.out.println("LocalDateTime : " + lt);
 }
 
-defineGlobalVariable()
-
 // added getNow() to easily switch between java.time.LocalDateTime.now() to Instant.now(). INstant.now() returns time in UTC where LocalDataTime returns local time without timezone. this leads to problems in case Jenkins Server and Keptn are in differnet timezones
 def getNow() {
     // return java.time.LocalDateTime.now()
@@ -436,6 +434,7 @@ def keptnAddStageResources(file, remoteUri) {
  */
 def markEvaluationStartTime() {
     //def startTime = getNow().toString()
+    defineGlobalVariable()
     
     def LocalDateTime starttimelocal = LocalDateTime.now()       
     //def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -6,6 +6,7 @@ import org.jenkinsci.plugins.plaincredentials.StringCredentials
 import com.cloudbees.plugins.credentials.CredentialsProvider
 import com.cloudbees.plugins.credentials.domains.DomainRequirement
 
+
 /**
  * Downloads a file from the given url and stores it in the local workspace
  */
@@ -26,7 +27,6 @@ def downloadFile(url, file) {
 
 def getKeptnContextJsonFilename() {return "keptn.context.${BUILD_NUMBER}.json"}
 def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
-def verbose=false
 /**
 * set the timezone
 * uses Jenkins timezone format denoted here https://gist.github.com/JinnaBalu/d630c37ef1f87cfcfa622c3a4e77d78c
@@ -711,8 +711,10 @@ def sendStartEvaluationEvent(Map args) {
 /**
  * waitForEvaluationDoneEvent(setBuildResult, [keptn_context, keptn_endpoint, keptn_api_token])
  */
-def waitForEvaluationDoneEvent(Map args, verbose) {
+def waitForEvaluationDoneEvent(Map args) {
     def keptnInit = keptnLoadFromInit(args)
+    
+    def verbose="false"
     
     Boolean setBuildResult = args.containsKey("setBuildResult") ? args.setBuildResult : false 
     int waitTime = args.containsKey("waitTime") ? args.waitTime : 3 // default is 3 minute wait 

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -438,7 +438,7 @@ def markEvaluationStartTime() {
     //def startTime = getNow().toString()
     defineGlobalVariable()
     
-    def LocalDateTime starttimelocal = LocalDateTime.now(zid)       
+    def LocalDateTime starttimelocal = LocalDateTime.now()       
     //def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
     
     startTime = timestampFormatter(starttimelocal)
@@ -577,7 +577,7 @@ def sendStartEvaluationEvent(Map args) {
             //starttime = getNow().minusSeconds((int)starttime.toInteger()).toString()
             //echo "Setting starttime to ${starttime}"
            
-            def LocalDateTime starttimelocal = LocalDateTime.now(zid)
+            def LocalDateTime starttimelocal = LocalDateTime.now()
             def LocalDateTime starttimeminus = starttimelocal.minusSeconds(seconds)            
             
             starttimeformatted = timestampFormatter(starttimeminus)
@@ -596,7 +596,7 @@ def sendStartEvaluationEvent(Map args) {
             //endtime = getNow().minusSeconds((int)endtime.toInteger()).toString()
             //echo "Setting endtime to ${endtime}"
             
-            def LocalDateTime endtimelocal = LocalDateTime.now(zid)
+            def LocalDateTime endtimelocal = LocalDateTime.now()
             def LocalDateTime endtimeminus = endtimelocal.minusSeconds(seconds)            
             
             endtimeformatted = timestampFormatter(endtimeminus)
@@ -611,7 +611,7 @@ def sendStartEvaluationEvent(Map args) {
     if (endtime == "") {
         //endtime = getNow().toString()
         
-        def LocalDateTime endtimelocal = LocalDateTime.now(zid)                        
+        def LocalDateTime endtimelocal = LocalDateTime.now()                        
         
         endtimeformatted = timestampFormatter(endtimelocal)
         

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -29,6 +29,7 @@ def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
 
 // create a clock
 def ZoneId zid = ZoneId.of("America/New_York");
+echo "TimeZone: ${zid}"
 
 // added getNow() to easily switch between java.time.LocalDateTime.now() to Instant.now(). INstant.now() returns time in UTC where LocalDataTime returns local time without timezone. this leads to problems in case Jenkins Server and Keptn are in differnet timezones
 def getNow(zid) {

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -33,7 +33,7 @@ def getNow() {
     return java.time.Instant.now()
 }
 
-def dateFormatter(timestamp) {
+def timestampFormatter(timestamp) {
     def timeformatted = timestamp.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
     return timeformatted
 }    
@@ -426,7 +426,7 @@ def markEvaluationStartTime() {
     def LocalDateTime starttimelocal = LocalDateTime.now()       
     def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
     
-    def timestampformatted = dateFormatter(starttimelocal)
+    timestampformatted = timestampFormatter[starttimelocal]
     echo "new timestamp formatted: ${timestampformatted}"
     
     startTime = starttimeformatted

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -35,7 +35,8 @@ def defineGlobalVariable() {
         LocalDateTime lt = LocalDateTime.now(zid);
   
         // print result
-        System.out.println("LocalDateTime : " + lt);
+        echo "LocalDateTime : ${lt}"
+        echo "TZ: ${zid}"
 }
 
 // added getNow() to easily switch between java.time.LocalDateTime.now() to Instant.now(). INstant.now() returns time in UTC where LocalDataTime returns local time without timezone. this leads to problems in case Jenkins Server and Keptn are in differnet timezones
@@ -538,6 +539,7 @@ def addCustomLabels(requestBody, labels) {
  */
 def sendStartEvaluationEvent(Map args) {
     def keptnInit = keptnLoadFromInit(args)
+    defineGlobalVariable()
     
     /* String project, String stage, String service, String deploymentURI, String testStrategy */
     String keptn_endpoint = keptnInit['keptn_endpoint']

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -446,6 +446,7 @@ def keptnAddStageResources(file, remoteUri) {
  */
 def markEvaluationStartTime(timezone) {
     // get timezone.  
+    echo "TZ: ${timezone}"
     zid = defineTZVariable(timezone)
     //def startTime = getNow().toString()       
     def LocalDateTime starttimelocal = LocalDateTime.now(zid)       

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -37,6 +37,7 @@ def defineGlobalVariable() {
         // print result
         echo "LocalDateTime : ${lt}"
         echo "TZ: ${zid}"
+        return zid
 }
 
 // added getNow() to easily switch between java.time.LocalDateTime.now() to Instant.now(). INstant.now() returns time in UTC where LocalDataTime returns local time without timezone. this leads to problems in case Jenkins Server and Keptn are in differnet timezones
@@ -438,7 +439,7 @@ def markEvaluationStartTime() {
     //def startTime = getNow().toString()
     defineGlobalVariable()
     
-    def LocalDateTime starttimelocal = LocalDateTime.now()       
+    def LocalDateTime starttimelocal = LocalDateTime.now(zid)       
     //def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
     
     startTime = timestampFormatter(starttimelocal)
@@ -576,8 +577,8 @@ def sendStartEvaluationEvent(Map args) {
         if (seconds > 0) {
             //starttime = getNow().minusSeconds((int)starttime.toInteger()).toString()
             //echo "Setting starttime to ${starttime}"
-           
-            def LocalDateTime starttimelocal = LocalDateTime.now()
+            
+            def LocalDateTime starttimelocal = LocalDateTime.now(zid)
             def LocalDateTime starttimeminus = starttimelocal.minusSeconds(seconds)            
             
             starttimeformatted = timestampFormatter(starttimeminus)
@@ -596,7 +597,7 @@ def sendStartEvaluationEvent(Map args) {
             //endtime = getNow().minusSeconds((int)endtime.toInteger()).toString()
             //echo "Setting endtime to ${endtime}"
             
-            def LocalDateTime endtimelocal = LocalDateTime.now()
+            def LocalDateTime endtimelocal = LocalDateTime.now(zid)
             def LocalDateTime endtimeminus = endtimelocal.minusSeconds(seconds)            
             
             endtimeformatted = timestampFormatter(endtimeminus)
@@ -611,7 +612,7 @@ def sendStartEvaluationEvent(Map args) {
     if (endtime == "") {
         //endtime = getNow().toString()
         
-        def LocalDateTime endtimelocal = LocalDateTime.now()                        
+        def LocalDateTime endtimelocal = LocalDateTime.now(zid)                        
         
         endtimeformatted = timestampFormatter(endtimelocal)
         

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -32,12 +32,10 @@ def defineTZVariable(timezone) {
 
     if (timezone == null || timezone == "") {
       timezone = "Etc/UTC"
-      def zid = ZoneId.of(timezone)
-      LocalDateTime lt = LocalDateTime.now(zid)       
+      def zid = ZoneId.of(timezone)      
     } else {
    	  timezone = timezone
    	  def zid = ZoneId.of(timezone)
-   	  LocalDateTime lt = LocalDateTime.now(zid);
     }
 
     echo "TZ: ${timezone}"
@@ -447,6 +445,7 @@ def keptnAddStageResources(file, remoteUri) {
 def markEvaluationStartTime(timezone) {
     // get timezone.  
     echo "TZ: ${timezone}"
+    
     zid = defineTZVariable(timezone)
     //def startTime = getNow().toString()       
     def LocalDateTime starttimelocal = LocalDateTime.now(zid)       

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -31,9 +31,9 @@ def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
 def ZoneId zid = ZoneId.of("America/New_York");
 
 // added getNow() to easily switch between java.time.LocalDateTime.now() to Instant.now(). INstant.now() returns time in UTC where LocalDataTime returns local time without timezone. this leads to problems in case Jenkins Server and Keptn are in differnet timezones
-def getNow() {
+def getNow(zid) {
     // return java.time.LocalDateTime.now()
-    return java.time.Instant.now()
+    return java.time.Instant.now(zid)
 }
 
 // use to format timestamps to conform with keptn

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -42,9 +42,9 @@ public class GFG {
 }
 
 // added getNow() to easily switch between java.time.LocalDateTime.now() to Instant.now(). INstant.now() returns time in UTC where LocalDataTime returns local time without timezone. this leads to problems in case Jenkins Server and Keptn are in differnet timezones
-def getNow(zid) {
+def getNow() {
     // return java.time.LocalDateTime.now()
-    return java.time.Instant.now(zid)
+    return java.time.Instant.now()
 }
 
 // use to format timestamps to conform with keptn
@@ -435,10 +435,10 @@ def keptnAddStageResources(file, remoteUri) {
 /** 
  * Stores the current local time in keptn.input.json
  */
-def markEvaluationStartTime(zid) {
+def markEvaluationStartTime() {
     //def startTime = getNow().toString()
     
-    def LocalDateTime starttimelocal = LocalDateTime.now(zid)       
+    def LocalDateTime starttimelocal = LocalDateTime.now()       
     //def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
     
     startTime = timestampFormatter(starttimelocal)
@@ -576,7 +576,7 @@ def sendStartEvaluationEvent(Map args) {
             //starttime = getNow().minusSeconds((int)starttime.toInteger()).toString()
             //echo "Setting starttime to ${starttime}"
            
-            def LocalDateTime starttimelocal = LocalDateTime.now(zid)
+            def LocalDateTime starttimelocal = LocalDateTime.now()
             def LocalDateTime starttimeminus = starttimelocal.minusSeconds(seconds)            
             
             starttimeformatted = timestampFormatter(starttimeminus)
@@ -595,7 +595,7 @@ def sendStartEvaluationEvent(Map args) {
             //endtime = getNow().minusSeconds((int)endtime.toInteger()).toString()
             //echo "Setting endtime to ${endtime}"
             
-            def LocalDateTime endtimelocal = LocalDateTime.now(zid)
+            def LocalDateTime endtimelocal = LocalDateTime.now()
             def LocalDateTime endtimeminus = endtimelocal.minusSeconds(seconds)            
             
             endtimeformatted = timestampFormatter(endtimeminus)
@@ -610,7 +610,7 @@ def sendStartEvaluationEvent(Map args) {
     if (endtime == "") {
         //endtime = getNow().toString()
         
-        def LocalDateTime endtimelocal = LocalDateTime.now(zid)                        
+        def LocalDateTime endtimelocal = LocalDateTime.now()                        
         
         endtimeformatted = timestampFormatter(endtimelocal)
         

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -42,9 +42,8 @@ def defineGlobalVariable() {
 
 // added getNow() to easily switch between java.time.LocalDateTime.now() to Instant.now(). INstant.now() returns time in UTC where LocalDataTime returns local time without timezone. this leads to problems in case Jenkins Server and Keptn are in differnet timezones
 def getNow() {
-    // return java.time.LocalDateTime.now()
-    defineGlobalVariable()
-    return java.time.Instant.now(zid)
+    // return java.time.LocalDateTime.now() 
+    return java.time.Instant.now()
 }
 
 // use to format timestamps to conform with keptn
@@ -437,8 +436,7 @@ def keptnAddStageResources(file, remoteUri) {
  */
 def markEvaluationStartTime() {
     //def startTime = getNow().toString()
-    defineGlobalVariable()
-    
+        
     def LocalDateTime starttimelocal = LocalDateTime.now()       
     //def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
     

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -528,7 +528,7 @@ def addCustomLabels(requestBody, labels) {
  * Timeframe from Now()-11minutes to Now()-1min: starttime=660, endtime=60
  * From starttime untile now: starttime="2020-04-17T11:30:00.000Z", endtime=""
  */
-def sendStartEvaluationEvent(Map args, zid) {
+def sendStartEvaluationEvent(Map args) {
     def keptnInit = keptnLoadFromInit(args)
     
     /* String project, String stage, String service, String deploymentURI, String testStrategy */

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -28,7 +28,9 @@ def getKeptnContextJsonFilename() {return "keptn.context.${BUILD_NUMBER}.json"}
 def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
 
 // set the timezone
-def defineTZVariable() {
+def defineTZVariable(timezone) {
+
+		echo "timezone: ${timezone}"
 
         //timezone = "Etc/UTC"       
         timezone = "America/New_York"
@@ -125,6 +127,7 @@ def keptnInit(Map args) {
     String stage = args.containsKey("stage") ? args.stage : ""
     String service = args.containsKey("service") ? args.service : ""
     String monitoring = args.containsKey("monitoring") ? args.monitoring : ""
+    String timezone = args.containsKey("timezone") ? args.timezone : ""
 
     if ((project == "") || (stage == "") || (service == "") ||
         (keptn_endpoint == null) || (keptn_bridge == null) || (keptn_api_token == null)) {
@@ -546,7 +549,10 @@ def addCustomLabels(requestBody, labels) {
  */
 def sendStartEvaluationEvent(Map args) {
     def keptnInit = keptnLoadFromInit(args)
-    zid = defineTZVariable()
+    
+    String timezone = keptnInit['timezone']
+    
+    zid = defineTZVariable(timezone)
         
     /* String project, String stage, String service, String deploymentURI, String testStrategy */
     String keptn_endpoint = keptnInit['keptn_endpoint']

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -26,7 +26,7 @@ def downloadFile(url, file) {
 
 def getKeptnContextJsonFilename() {return "keptn.context.${BUILD_NUMBER}.json"}
 def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
-
+def verbose=false
 /**
 * set the timezone
 * uses Jenkins timezone format denoted here https://gist.github.com/JinnaBalu/d630c37ef1f87cfcfa622c3a4e77d78c
@@ -762,7 +762,9 @@ def waitForEvaluationDoneEvent(Map args) {
                     return false  
                 } else {
                     evalResponse = response.content
-                    echo "eval response: ${evalResponse}" 
+                    if (verbose == "true") {
+                    echo "eval response: ${evalResponse}"
+                    }    
                     return true
                 } 
             }

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -425,7 +425,7 @@ def keptnAddStageResources(file, remoteUri) {
 /** 
  * Stores the current local time in keptn.input.json
  */
-def markEvaluationStartTime() {
+def markEvaluationStartTime(zid) {
     //def startTime = getNow().toString()
     
     def LocalDateTime starttimelocal = LocalDateTime.now(zid)       
@@ -528,7 +528,7 @@ def addCustomLabels(requestBody, labels) {
  * Timeframe from Now()-11minutes to Now()-1min: starttime=660, endtime=60
  * From starttime untile now: starttime="2020-04-17T11:30:00.000Z", endtime=""
  */
-def sendStartEvaluationEvent(Map args) {
+def sendStartEvaluationEvent(Map args, zid) {
     def keptnInit = keptnLoadFromInit(args)
     
     /* String project, String stage, String service, String deploymentURI, String testStrategy */

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -568,7 +568,7 @@ def sendStartEvaluationEvent(Map args) {
             
             def starttimeformatted = starttimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
             
-            timestampformatted = timestampFormatter[starttimelocal]
+            timestampformatted = timestampFormatter(starttimelocal)
             echo "new timestamp formatted: ${timestampformatted}"
             
             starttime = starttimeformatted

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -29,8 +29,8 @@ def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
 
 // set the timezone
 def defineTZVariable() {
-        //timezone = "America/New_York"
-        timezone = "Etc/UTC"
+        timezone = "America/New_York"
+        //timezone = "Etc/UTC"
         
         def zid = ZoneId.of(timezone);
   

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -30,17 +30,14 @@ def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
 public class GFG {
     public static void main(String[] args)
     {
-  
         // create a clock
         ZoneId zid = ZoneId.of("Europe/Paris");
   
         // create an LocalDateTime object using now(zoneId)
-        LocalDateTime lt
-            = LocalDateTime.now(zid);
+        LocalDateTime lt = LocalDateTime.now(zid);
   
         // print result
-        System.out.println("LocalDateTime : "
-                           + lt);
+        System.out.println("LocalDateTime : " + lt);
     }
 }
 

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -26,11 +26,12 @@ def downloadFile(url, file) {
 
 def getKeptnContextJsonFilename() {return "keptn.context.${BUILD_NUMBER}.json"}
 def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
+def timezone = "America/New_York"
 
 // set the timezone
-def defineTZVariable() {
+def defineTZVariable(timezone) {
         // create a clock
-        timezone = "America/New_York"
+        timezone = timezone
         
         def zid = ZoneId.of(timezone);
   
@@ -52,7 +53,7 @@ def timestampFormatter(timestamp) {
 // added getNow() to easily switch between java.time.LocalDateTime.now() to Instant.now(). INstant.now() returns time in UTC where LocalDataTime returns local time without timezone. this leads to problems in case Jenkins Server and Keptn are in differnet timezones
 def getNow() {
     // get timezone.
-    zid = defineTZVariable()
+    zid = defineTZVariable(timezone)
     // return java.time.LocalDateTime.now() 
     return java.time.Instant.now(zid)
 }
@@ -441,7 +442,7 @@ def keptnAddStageResources(file, remoteUri) {
  */
 def markEvaluationStartTime() {
     // get timezone.
-    zid = defineTZVariable()
+    zid = defineTZVariable(timezone)
     //def startTime = getNow().toString()       
     def LocalDateTime starttimelocal = LocalDateTime.now(zid)       
     //def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
@@ -545,7 +546,7 @@ def addCustomLabels(requestBody, labels) {
  */
 def sendStartEvaluationEvent(Map args) {
     def keptnInit = keptnLoadFromInit(args)
-    zid = defineTZVariable()
+    zid = defineTZVariable(timezone)
         
     /* String project, String stage, String service, String deploymentURI, String testStrategy */
     String keptn_endpoint = keptnInit['keptn_endpoint']

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -578,7 +578,7 @@ def sendStartEvaluationEvent(Map args) {
             //echo "Setting starttime to ${starttime}"
             defineGlobalVariable()
             
-            def LocalDateTime starttimelocal = LocalDateTime.now(zid)
+            def LocalDateTime starttimelocal = LocalDateTime.now()
             def LocalDateTime starttimeminus = starttimelocal.minusSeconds(seconds)            
             
             starttimeformatted = timestampFormatter(starttimeminus)

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -276,7 +276,8 @@ def keptnInit(Map args) {
  */
 def keptnProjectExists(Map args) {
     def keptnInit = keptnLoadFromInit(args)
-
+    def verbose="false"
+    
     def getProjectResponse = httpRequest customHeaders: [[maskValue: true, name: 'x-token', value: "${keptnInit['keptn_api_token']}"]], 
         httpMode: 'GET', 
         responseHandle: 'STRING', 
@@ -285,7 +286,10 @@ def keptnProjectExists(Map args) {
         ignoreSslErrors: true,
         quiet: true
 
+    if (verbose == "true") {
     echo "Response from get project: " + getProjectResponse.content
+    }
+        
     if(getProjectResponse.content != "null") {
     return (getProjectResponse.status == 200)
     }    
@@ -296,7 +300,8 @@ def keptnProjectExists(Map args) {
  */
 def keptnProjectStageExists(Map args) {
     def keptnInit = keptnLoadFromInit(args)
-
+    def verbose="false"
+    
     def getProjectStageResponse = httpRequest customHeaders: [[maskValue: true, name: 'x-token', value: "${keptnInit['keptn_api_token']}"]], 
         httpMode: 'GET', 
         responseHandle: 'STRING', 
@@ -304,9 +309,11 @@ def keptnProjectStageExists(Map args) {
         validResponseCodes: "100:404",
         ignoreSslErrors: true,
         quiet: true
-
+    
+    if (verbose == "true") {
     echo "Response from get project stage: " + getProjectStageResponse.content
-
+    }
+        
     return (getProjectStageResponse.status == 200)
 }
 
@@ -315,7 +322,8 @@ def keptnProjectStageExists(Map args) {
  */
 def keptnProjectServiceExists(Map args) {
     def keptnInit = keptnLoadFromInit(args)
-
+    def verbose="false"
+    
     def getProjectServiceResponse = httpRequest customHeaders: [[maskValue: true, name: 'x-token', value: "${keptnInit['keptn_api_token']}"]], 
         httpMode: 'GET', 
         responseHandle: 'STRING', 
@@ -324,8 +332,10 @@ def keptnProjectServiceExists(Map args) {
         ignoreSslErrors: true,
         quiet: true
 
+    if (verbose == "true") {
     echo "Response from get project service: " + getProjectServiceResponse.content
-
+    }
+        
     return (getProjectServiceResponse.status == 200)
 }
 
@@ -334,7 +344,8 @@ def keptnProjectServiceExists(Map args) {
  */
 def keptnDeleteProject(Map args) {
     def keptnInit = keptnLoadFromInit(args)
-
+    def verbose="false"
+    
     def deleteProjectResponse = httpRequest contentType: 'APPLICATION_JSON', 
         customHeaders: [[maskValue: true, name: 'x-token', value: "${keptnInit['keptn_api_token']}"]], 
         httpMode: 'DELETE', 
@@ -343,8 +354,9 @@ def keptnDeleteProject(Map args) {
         validResponseCodes: "100:404",
         ignoreSslErrors: true,
         quiet: true
-
+    if (verbose == "true") {
     echo "Response from delete project: " + deleteProjectResponse.content
+    }    
 }
 
 

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -33,6 +33,7 @@ def getNow() {
     return java.time.Instant.now()
 }
 
+// use to format timestamps to conform with keptn
 def timestampFormatter(timestamp) {
     def timeformatted = timestamp.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
     return timeformatted
@@ -427,7 +428,7 @@ def markEvaluationStartTime() {
     //def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
     
     startTime = timestampFormatter(starttimelocal)
-    //startTime = starttimeformatted
+
     echo "write starttime to file - ${startTime}"
     
     def keptnContextFileJson
@@ -564,8 +565,6 @@ def sendStartEvaluationEvent(Map args) {
             def LocalDateTime starttimelocal = LocalDateTime.now()
             def LocalDateTime starttimeminus = starttimelocal.minusSeconds(seconds)            
             
-            //def starttimeformatted = starttimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
-            
             starttimeformatted = timestampFormatter(starttimeminus)
             
             starttime = starttimeformatted
@@ -584,8 +583,6 @@ def sendStartEvaluationEvent(Map args) {
             
             def LocalDateTime endtimelocal = LocalDateTime.now()
             def LocalDateTime endtimeminus = endtimelocal.minusSeconds(seconds)            
-                     
-            //def endtimeformatted = endtimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
             
             endtimeformatted = timestampFormatter(endtimeminus)
             
@@ -600,7 +597,6 @@ def sendStartEvaluationEvent(Map args) {
         //endtime = getNow().toString()
         
         def LocalDateTime endtimelocal = LocalDateTime.now()                        
-        //def endtimeformatted = endtimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
         
         endtimeformatted = timestampFormatter(endtimelocal)
         

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -27,9 +27,7 @@ def downloadFile(url, file) {
 def getKeptnContextJsonFilename() {return "keptn.context.${BUILD_NUMBER}.json"}
 def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
 
-public class GFG {
-    public static void main(String[] args)
-    {
+def defineGlobalVariable() {
         // create a clock
         ZoneId zid = ZoneId.of("Europe/Paris");
   
@@ -38,10 +36,9 @@ public class GFG {
   
         // print result
         System.out.println("LocalDateTime : " + lt);
-    }
 }
 
-GFG()
+defineGlobalVariable()
 
 // added getNow() to easily switch between java.time.LocalDateTime.now() to Instant.now(). INstant.now() returns time in UTC where LocalDataTime returns local time without timezone. this leads to problems in case Jenkins Server and Keptn are in differnet timezones
 def getNow() {

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -424,12 +424,10 @@ def markEvaluationStartTime() {
     //def startTime = getNow().toString()
     
     def LocalDateTime starttimelocal = LocalDateTime.now()       
-    def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
+    //def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
     
-    timestampformatted = timestampFormatter[starttimelocal]
-    echo "new timestamp formatted: ${timestampformatted}"
-    
-    startTime = starttimeformatted
+    startTime = timestampFormatter(starttimelocal)
+    //startTime = starttimeformatted
     echo "write starttime to file - ${startTime}"
     
     def keptnContextFileJson
@@ -566,10 +564,9 @@ def sendStartEvaluationEvent(Map args) {
             def LocalDateTime starttimelocal = LocalDateTime.now()
             def LocalDateTime starttimeminus = starttimelocal.minusSeconds(seconds)            
             
-            def starttimeformatted = starttimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
+            //def starttimeformatted = starttimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
             
-            timestampformatted = timestampFormatter(starttimelocal)
-            echo "new timestamp formatted: ${timestampformatted}"
+            starttimeformatted = timestampFormatter(starttimeminus)
             
             starttime = starttimeformatted
          
@@ -588,7 +585,9 @@ def sendStartEvaluationEvent(Map args) {
             def LocalDateTime endtimelocal = LocalDateTime.now()
             def LocalDateTime endtimeminus = endtimelocal.minusSeconds(seconds)            
                      
-            def endtimeformatted = endtimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
+            //def endtimeformatted = endtimeminus.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
+            
+            endtimeformatted = timestampFormatter(endtimeminus)
             
             endtime = endtimeformatted            
             echo "Setting endtime to ${endtime}"         
@@ -601,8 +600,10 @@ def sendStartEvaluationEvent(Map args) {
         //endtime = getNow().toString()
         
         def LocalDateTime endtimelocal = LocalDateTime.now()                        
-        def endtimeformatted = endtimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
-            
+        //def endtimeformatted = endtimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
+        
+        endtimeformatted = timestampFormatter(endtimelocal)
+        
         endtime = endtimeformatted    
         echo "Endttime empty. Setting endtime to Now: ${endtime}"
     }

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -29,7 +29,7 @@ def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
 
 def defineGlobalVariable() {
         // create a clock
-        ZoneId zid = ZoneId.of("Europe/Paris");
+        ZoneId zid = ZoneId.of("America/New_York");
   
         // create an LocalDateTime object using now(zoneId)
         LocalDateTime lt = LocalDateTime.now(zid);
@@ -42,7 +42,8 @@ def defineGlobalVariable() {
 // added getNow() to easily switch between java.time.LocalDateTime.now() to Instant.now(). INstant.now() returns time in UTC where LocalDataTime returns local time without timezone. this leads to problems in case Jenkins Server and Keptn are in differnet timezones
 def getNow() {
     // return java.time.LocalDateTime.now()
-    return java.time.Instant.now()
+    defineGlobalVariable()
+    return java.time.Instant.now(zid)
 }
 
 // use to format timestamps to conform with keptn
@@ -437,7 +438,7 @@ def markEvaluationStartTime() {
     //def startTime = getNow().toString()
     defineGlobalVariable()
     
-    def LocalDateTime starttimelocal = LocalDateTime.now()       
+    def LocalDateTime starttimelocal = LocalDateTime.now(zid)       
     //def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
     
     startTime = timestampFormatter(starttimelocal)
@@ -576,7 +577,7 @@ def sendStartEvaluationEvent(Map args) {
             //starttime = getNow().minusSeconds((int)starttime.toInteger()).toString()
             //echo "Setting starttime to ${starttime}"
            
-            def LocalDateTime starttimelocal = LocalDateTime.now()
+            def LocalDateTime starttimelocal = LocalDateTime.now(zid)
             def LocalDateTime starttimeminus = starttimelocal.minusSeconds(seconds)            
             
             starttimeformatted = timestampFormatter(starttimeminus)
@@ -595,7 +596,7 @@ def sendStartEvaluationEvent(Map args) {
             //endtime = getNow().minusSeconds((int)endtime.toInteger()).toString()
             //echo "Setting endtime to ${endtime}"
             
-            def LocalDateTime endtimelocal = LocalDateTime.now()
+            def LocalDateTime endtimelocal = LocalDateTime.now(zid)
             def LocalDateTime endtimeminus = endtimelocal.minusSeconds(seconds)            
             
             endtimeformatted = timestampFormatter(endtimeminus)
@@ -610,7 +611,7 @@ def sendStartEvaluationEvent(Map args) {
     if (endtime == "") {
         //endtime = getNow().toString()
         
-        def LocalDateTime endtimelocal = LocalDateTime.now()                        
+        def LocalDateTime endtimelocal = LocalDateTime.now(zid)                        
         
         endtimeformatted = timestampFormatter(endtimelocal)
         

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -28,7 +28,7 @@ def getKeptnContextJsonFilename() {return "keptn.context.${BUILD_NUMBER}.json"}
 def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
 
 // create a clock
-def ZoneId zid = ZoneId.of("America/New_York");
+ZoneId zid = ZoneId.of("America/New_York");
 echo "TimeZone: ${zid}"
 
 // added getNow() to easily switch between java.time.LocalDateTime.now() to Instant.now(). INstant.now() returns time in UTC where LocalDataTime returns local time without timezone. this leads to problems in case Jenkins Server and Keptn are in differnet timezones

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -41,6 +41,8 @@ public class GFG {
     }
 }
 
+GFG()
+
 // added getNow() to easily switch between java.time.LocalDateTime.now() to Instant.now(). INstant.now() returns time in UTC where LocalDataTime returns local time without timezone. this leads to problems in case Jenkins Server and Keptn are in differnet timezones
 def getNow() {
     // return java.time.LocalDateTime.now()

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -30,7 +30,7 @@ def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
 // set the timezone
 def defineTZVariable(timezone) {
 
-    if (timezone == null) {
+    if (timezone == null || timezone == "") {
       timezone = "Etc/UTC"
       def zid = ZoneId.of(timezone)
       LocalDateTime lt = LocalDateTime.now(zid)       

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -449,7 +449,6 @@ def markEvaluationStartTime(timezone) {
     zid = defineTZVariable(timezone)
     //def startTime = getNow().toString()       
     def LocalDateTime starttimelocal = LocalDateTime.now(zid)       
-    //def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
     
     startTime = timestampFormatter(starttimelocal)
 

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -718,7 +718,6 @@ def waitForEvaluationDoneEvent(Map args) {
                     return false  
                 } else {
                     evalResponse = response.content
-                    echo "response content: ${response.content}"
                     echo "eval response: ${evalResponse}" 
                     return true
                 } 

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -40,7 +40,7 @@ def defineTZVariable(timezone) {
   
     // create an LocalDateTime object using now(zoneId)
     LocalDateTime lt = LocalDateTime.now(zid);
-
+    echo "TZ: ${timezone}"
     return zid
 }
 

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -29,8 +29,8 @@ def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
 
 // set the timezone
 def defineTZVariable() {
-        // create a clock
-        timezone = "America/New_York"
+        //timezone = "America/New_York"
+        timezone = "Etc/UTC"
         
         def zid = ZoneId.of(timezone);
   

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -27,9 +27,11 @@ def downloadFile(url, file) {
 def getKeptnContextJsonFilename() {return "keptn.context.${BUILD_NUMBER}.json"}
 def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
 
-// create a clock
-ZoneId zid = ZoneId.of("America/New_York");
-echo "TimeZone: ${zid}"
+def defineGlobalVariable() {
+    // create a clock
+    ZoneId zid = ZoneId.of("America/New_York");
+    echo "TimeZone: ${zid}"
+}
 
 // added getNow() to easily switch between java.time.LocalDateTime.now() to Instant.now(). INstant.now() returns time in UTC where LocalDataTime returns local time without timezone. this leads to problems in case Jenkins Server and Keptn are in differnet timezones
 def getNow(zid) {

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -711,7 +711,7 @@ def sendStartEvaluationEvent(Map args) {
 /**
  * waitForEvaluationDoneEvent(setBuildResult, [keptn_context, keptn_endpoint, keptn_api_token])
  */
-def waitForEvaluationDoneEvent(Map args) {
+def waitForEvaluationDoneEvent(Map args, verbose) {
     def keptnInit = keptnLoadFromInit(args)
     
     Boolean setBuildResult = args.containsKey("setBuildResult") ? args.setBuildResult : false 

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -32,8 +32,11 @@ def defineTZVariable(timezone) {
 
 		echo "timezone: ${timezone}"
 
-        //timezone = "Etc/UTC"       
-        timezone = "America/New_York"
+		if (timezone == null) {
+        	timezone = "Etc/UTC"       
+        } else {
+        	timezone = timezone
+        }
         
         def zid = ZoneId.of(timezone);
   
@@ -55,7 +58,10 @@ def timestampFormatter(timestamp) {
 // added getNow() to easily switch between java.time.LocalDateTime.now() to Instant.now(). INstant.now() returns time in UTC where LocalDataTime returns local time without timezone. this leads to problems in case Jenkins Server and Keptn are in differnet timezones
 def getNow() {
     // get timezone.
-    zid = defineTZVariable()
+    def keptnInit = keptnLoadFromInit(args)
+    
+    String timezone = keptnInit['timezone']
+    zid = defineTZVariable(timezone)
     // return java.time.LocalDateTime.now() 
     return java.time.Instant.now(zid)
 }
@@ -445,7 +451,10 @@ def keptnAddStageResources(file, remoteUri) {
  */
 def markEvaluationStartTime() {
     // get timezone.
-    zid = defineTZVariable()
+    def keptnInit = keptnLoadFromInit(args)
+    
+    String timezone = keptnInit['timezone']
+    zid = defineTZVariable(timezone)
     //def startTime = getNow().toString()       
     def LocalDateTime starttimelocal = LocalDateTime.now(zid)       
     //def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
@@ -550,8 +559,7 @@ def addCustomLabels(requestBody, labels) {
 def sendStartEvaluationEvent(Map args) {
     def keptnInit = keptnLoadFromInit(args)
     
-    String timezone = keptnInit['timezone']
-    
+    String timezone = keptnInit['timezone'] 
     zid = defineTZVariable(timezone)
         
     /* String project, String stage, String service, String deploymentURI, String testStrategy */

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -29,7 +29,7 @@ def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
 
 def defineGlobalVariable() {
         // create a clock
-        ZoneId zid = ZoneId.of("America/New_York");
+        def zid = ZoneId.of("America/New_York");
   
         // create an LocalDateTime object using now(zoneId)
         LocalDateTime lt = LocalDateTime.now(zid);

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -27,9 +27,12 @@ def downloadFile(url, file) {
 def getKeptnContextJsonFilename() {return "keptn.context.${BUILD_NUMBER}.json"}
 def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
 
+// set the timezone
 def defineTZVariable() {
         // create a clock
-        def zid = ZoneId.of("America/New_York");
+        timezone = "America/New_York"
+        
+        def zid = ZoneId.of(timezone);
   
         // create an LocalDateTime object using now(zoneId)
         LocalDateTime lt = LocalDateTime.now(zid);
@@ -40,6 +43,12 @@ def defineTZVariable() {
         return zid
 }
 
+// use to format timestamps to conform with keptn
+def timestampFormatter(timestamp) {
+    def timeformatted = timestamp.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
+    return timeformatted
+}    
+
 // added getNow() to easily switch between java.time.LocalDateTime.now() to Instant.now(). INstant.now() returns time in UTC where LocalDataTime returns local time without timezone. this leads to problems in case Jenkins Server and Keptn are in differnet timezones
 def getNow() {
     // get timezone.
@@ -47,12 +56,6 @@ def getNow() {
     // return java.time.LocalDateTime.now() 
     return java.time.Instant.now(zid)
 }
-
-// use to format timestamps to conform with keptn
-def timestampFormatter(timestamp) {
-    def timeformatted = timestamp.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
-    return timeformatted
-}    
 
 String getKeptnApiToken() {
     String keptn_api_token = env.KEPTN_API_TOKEN

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -28,16 +28,10 @@ def getKeptnContextJsonFilename() {return "keptn.context.${BUILD_NUMBER}.json"}
 def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
 
 // set the timezone
-def defineTZVariable(Map args) {
+def defineTZVariable() {
 
-		String timezone = args.containsKey("timezone") ? args.timezone : ""
-		
-		if ((timezone == "")) {
-        timezone = "Etc/UTC"
-        }
-        
+        //timezone = "Etc/UTC"       
         timezone = "America/New_York"
-        
         
         def zid = ZoneId.of(timezone);
   

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -31,13 +31,13 @@ def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
 def defineTZVariable(timezone) {
 
     if (timezone == null || timezone == "") {
-      timezone = "UTC"
-      def zid = ZoneId.of(timezone)      
+      timezone = "UTC"     
     } else {
    	  timezone = timezone
-   	  def zid = ZoneId.of(timezone)
     }
 
+    def zid = ZoneId.of(timezone)
+    
     echo "TZ: ${timezone}"
     echo "ZID: ${zid}"
     return zid

--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -27,6 +27,9 @@ def downloadFile(url, file) {
 def getKeptnContextJsonFilename() {return "keptn.context.${BUILD_NUMBER}.json"}
 def getKeptnInitJsonFilename() {return "keptn.init.${BUILD_NUMBER}.json"}
 
+// create a clock
+def ZoneId zid = ZoneId.of("America/New_York");
+
 // added getNow() to easily switch between java.time.LocalDateTime.now() to Instant.now(). INstant.now() returns time in UTC where LocalDataTime returns local time without timezone. this leads to problems in case Jenkins Server and Keptn are in differnet timezones
 def getNow() {
     // return java.time.LocalDateTime.now()
@@ -424,7 +427,7 @@ def keptnAddStageResources(file, remoteUri) {
 def markEvaluationStartTime() {
     //def startTime = getNow().toString()
     
-    def LocalDateTime starttimelocal = LocalDateTime.now()       
+    def LocalDateTime starttimelocal = LocalDateTime.now(zid)       
     //def starttimeformatted = starttimelocal.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
     
     startTime = timestampFormatter(starttimelocal)
@@ -562,7 +565,7 @@ def sendStartEvaluationEvent(Map args) {
             //starttime = getNow().minusSeconds((int)starttime.toInteger()).toString()
             //echo "Setting starttime to ${starttime}"
            
-            def LocalDateTime starttimelocal = LocalDateTime.now()
+            def LocalDateTime starttimelocal = LocalDateTime.now(zid)
             def LocalDateTime starttimeminus = starttimelocal.minusSeconds(seconds)            
             
             starttimeformatted = timestampFormatter(starttimeminus)
@@ -581,7 +584,7 @@ def sendStartEvaluationEvent(Map args) {
             //endtime = getNow().minusSeconds((int)endtime.toInteger()).toString()
             //echo "Setting endtime to ${endtime}"
             
-            def LocalDateTime endtimelocal = LocalDateTime.now()
+            def LocalDateTime endtimelocal = LocalDateTime.now(zid)
             def LocalDateTime endtimeminus = endtimelocal.minusSeconds(seconds)            
             
             endtimeformatted = timestampFormatter(endtimeminus)
@@ -596,7 +599,7 @@ def sendStartEvaluationEvent(Map args) {
     if (endtime == "") {
         //endtime = getNow().toString()
         
-        def LocalDateTime endtimelocal = LocalDateTime.now()                        
+        def LocalDateTime endtimelocal = LocalDateTime.now(zid)                        
         
         endtimeformatted = timestampFormatter(endtimelocal)
         


### PR DESCRIPTION
**Changes/imporvements**

- Moved timestamp formatting to function
- Created timezone function that allows an optional timezone to be passed.

**Usage**
use to set the timezone

uses Jenkins timezone format denoted here https://gist.github.com/JinnaBalu/d630c37ef1f87cfcfa622c3a4e77d78c

default timezone is "UTC"

When you trigger a keptn.sendStartEvaluationEvent you can pass in an optional timezone.
`def keptnContext = keptn.sendStartEvaluationEvent starttime:"${params.StartTime}", endtime:"${params.EndTime}", timezone:"${params.TimeZone}"`

When you mark the evaluation start time you can pass in an optional timezone.
`keptn.markEvaluationStartTime("${params.TimeZone}")`

**TODO:** 
Add this information to the documentation denoting an optional timezone parameter.  Also noting that the default timezone will use "UTC" if no timezone is passed.

 