### PR TITLE
#56 Fail addResource commands if the returning http status code is 4xx or 5xx

### DIFF
--- a/src/sh/keptn/Keptn.groovy
+++ b/src/sh/keptn/Keptn.groovy
@@ -340,7 +340,7 @@ def keptnAddResources(file, remoteUri) {
             requestBody: requestBody, 
             responseHandle: 'STRING', 
             url: "${keptnInit['keptn_endpoint']}/configuration-service/v1/project/${keptnInit['project']}/stage/${keptnInit['stage']}/service/${keptnInit['service']}/resource", 
-            validResponseCodes: "100:404",
+            validResponseCodes: "100:399",
             ignoreSslErrors: true
 
         echo "Response from upload resource ${file} to ${remoteUri}: " + addResourceResponse.content
@@ -374,7 +374,7 @@ def keptnAddProjectResources(file, remoteUri) {
             requestBody: requestBody, 
             responseHandle: 'STRING', 
             url: "${keptnInit['keptn_endpoint']}/configuration-service/v1/project/${keptnInit['project']}/resource", 
-            validResponseCodes: "100:404",
+            validResponseCodes: "100:399",
             ignoreSslErrors: true
 
         echo "Response from upload resource ${file} to ${remoteUri}: " + addResourceResponse.content
@@ -408,7 +408,7 @@ def keptnAddStageResources(file, remoteUri) {
             requestBody: requestBody, 
             responseHandle: 'STRING', 
             url: "${keptnInit['keptn_endpoint']}/configuration-service/v1/project/${keptnInit['project']}/stage/${keptnInit['stage']}/resource", 
-            validResponseCodes: "100:404",
+            validResponseCodes: "100:399",
             ignoreSslErrors: true
 
         echo "Response from upload resource ${file} to ${remoteUri}: " + addResourceResponse.content


### PR DESCRIPTION
# This PR

- reduces the allowed http response-codes for add-resource functions from 100 to 399
- Fixes #56