### PR TITLE
chore: pre-release pipeline should not require a dedicated access token

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,10 +1,8 @@
-name: Pre-Release
+name: Create Pre-Release
 on:
   workflow_dispatch:
 env:
   NODE_VERSION: 14 # needed for npx
-  KEPTN_BOT_NAME: "Keptn Sandbox Bot"
-  KEPTN_BOT_EMAIL: "keptn-sandbox-bot <95227801+keptn-sandbox-bot@users.noreply.github.com>"
   RELEASE_NOTES_FILE: "RELEASE-BODY.md"
   PRERELEASE_KEYWORD: "next"
 defaults:
@@ -31,20 +29,16 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          token: ${{ secrets.KEPTN_BOT_TOKEN }}
 
       - name: Set up Node.js # needed for npx
         uses: actions/setup-node@v2
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Configure Git
-        env:
-          KEPTN_BOT_NAME: ${{ env.KEPTN_BOT_NAME }}
-          KEPTN_BOT_EMAIL: ${{ env.KEPTN_BOT_EMAIL }}
+      - name: Configure Git # Using github.actor - whoever starts the pre-release workflow will own the tag
         run: |
-          git config user.name "$KEPTN_BOT_NAME"
-          git config user.email "$KEPTN_BOT_EMAIL"
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
 
       - name: Prepare GitHub Release Notes
         run: |
@@ -58,8 +52,6 @@ jobs:
 
       - name: Create pre-release package
         id: create-release-package
-        env:
-          GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
         run: |
           echo "🚀 Creating pre-release package now..."
           npx standard-version@^9.3.1 --prerelease "${{ env.PRERELEASE_KEYWORD }}" --skip.commit --skip.changelog
@@ -70,7 +62,7 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
           RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "$RELEASE_TAG" --prerelease --notes-file "${{ env.RELEASE_NOTES_FILE }}" --title "$RELEASE_TAG"


### PR DESCRIPTION
## This PR

- Removes any external access token from the pre-release workflow

Proof (done in a fork):
![image](https://user-images.githubusercontent.com/56065213/144051071-823d1cb1-af59-4227-944f-816bf2432810.png)
