### PR TITLE
chore: use pre-major in versionrc

### DIFF
--- a/.versionrc.json
+++ b/.versionrc.json
@@ -1,5 +1,6 @@
 {
     "tagPrefix": "",
+    "preMajor": true,
     "types": [
       {
         "type": "feat",


### PR DESCRIPTION
## This PR

- Changes .versionrc to use  pre-major versions
