### PR TITLE
refactor: separate monitoring configuration from project initialization

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -177,3 +177,10 @@ If the service already exists, skip creation of the service.
 * README contains an example of how to call this function within a Jenkinsfile
 * Finished event appears in Keptn Bridge (check for source="jenkins-library")
 
+### User Story 12: Configure monitoring for keptn project
+
+**Goal**: A user should be able to configure monitoring for a project after adding the relevant files to the Keptn configuration repo (SLIs/SLOs and monitoring config files as needed)
+
+**DoD**:
+* Shared library code contains function `keptnConfigureMonitoring` to trigger the appropriate event.
+* README contains an example of how to call this function within a Jenkinsfile for prometheus and dynatrace

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ keptn.keptnAddResources('keptn/sli.yaml','dynatrace/sli.yaml')
 keptn.keptnAddResources('keptn/slo.yaml','slo.yaml')
 keptn.keptnAddResources('keptn/load.jmx','jmeter/load.jmx')
 
+// Configure monitoring for your keptn project (using dynatrace or prometheus)
+keptn.keptnConfigureMonitoring monitoring:"dynatrace"
+// keptn.keptnConfigureMonitoring monitoring:"prometheus"
+
 // Custom Labels
 // all keptn.send** functions have an optional parameter called labels. It is a way to pass custom labels to the sent event
 def labels=[:]


### PR DESCRIPTION
Remove monitoring configuration from `keptnInit` and introduce a new function `keptnConfigureMonitoring` to be called after all the appropriate resources have been added to the keptn project.
If `monitoring` is still passed to `keptnInit` the pipeline will fail with an appropriate error message.

Signed-off-by: Paolo Chila <paolo.chila@dynatrace.com>
BREAKING CHANGE: passing a monitoring type during init will make the pipeline fail! Please remove the argument and use keptnConfigureMonitoring